### PR TITLE
Extra data based pricing

### DIFF
--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/LineaPluginTestBase.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/LineaPluginTestBase.java
@@ -67,7 +67,7 @@ public class LineaPluginTestBase extends AcceptanceTestBase {
   public void setup() throws Exception {
     minerNode =
         besu.createCliqueNodeWithExtraCliOptionsAndRpcApis(
-            "miner1", LINEA_CLIQUE_OPTIONS, getTestCliOptions(), Set.of("LINEA"));
+            "miner1", LINEA_CLIQUE_OPTIONS, getTestCliOptions(), Set.of("LINEA", "MINER"));
     minerNode.setTransactionPoolConfiguration(
         ImmutableTransactionPoolConfiguration.builder()
             .from(TransactionPoolConfiguration.DEFAULT)

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/ProfitableTransactionTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/ProfitableTransactionTest.java
@@ -30,18 +30,12 @@ import org.web3j.tx.RawTransactionManager;
 import org.web3j.tx.TransactionManager;
 
 public class ProfitableTransactionTest extends LineaPluginTestBase {
-  private static final int VERIFICATION_GAS_COST = 1_200_000;
-  private static final int VERIFICATION_CAPACITY = 90_000;
-  private static final int GAS_PRICE_RATIO = 15;
-  private static final double MIN_MARGIN = 1.0;
+  private static final double MIN_MARGIN = 1.5;
   private static final Wei MIN_GAS_PRICE = Wei.of(1_000_000_000);
 
   @Override
   public List<String> getTestCliOptions() {
     return new TestCommandLineOptionsBuilder()
-        .set("--plugin-linea-verification-gas-cost=", String.valueOf(VERIFICATION_GAS_COST))
-        .set("--plugin-linea-verification-capacity=", String.valueOf(VERIFICATION_CAPACITY))
-        .set("--plugin-linea-gas-price-ratio=", String.valueOf(GAS_PRICE_RATIO))
         .set("--plugin-linea-min-margin=", String.valueOf(MIN_MARGIN))
         .build();
   }
@@ -70,7 +64,7 @@ public class ProfitableTransactionTest extends LineaPluginTestBase {
 
     final var txUnprofitable =
         txManager.sendTransaction(
-            MIN_GAS_PRICE.getAsBigInteger(),
+            MIN_GAS_PRICE.getAsBigInteger().divide(BigInteger.valueOf(100)),
             BigInteger.valueOf(MAX_TX_GAS_LIMIT / 2),
             credentials.getAddress(),
             txData.toString(),

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/extradata/ExtraDataPricingTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/extradata/ExtraDataPricingTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package linea.plugin.acc.test.extradata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+
+import linea.plugin.acc.test.LineaPluginTestBase;
+import linea.plugin.acc.test.TestCommandLineOptionsBuilder;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt32;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
+import org.hyperledger.besu.tests.acceptance.dsl.account.Accounts;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.NodeRequests;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.account.TransferTransaction;
+import org.junit.jupiter.api.Test;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.RawTransaction;
+import org.web3j.crypto.TransactionEncoder;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.utils.Numeric;
+
+public class ExtraDataPricingTest extends LineaPluginTestBase {
+  private static final Wei MIN_GAS_PRICE = Wei.of(1_000_000_000);
+  private static final int WEI_IN_KWEI = 1000;
+
+  @Override
+  public List<String> getTestCliOptions() {
+    return getTestCommandLineOptionsBuilder().build();
+  }
+
+  protected TestCommandLineOptionsBuilder getTestCommandLineOptionsBuilder() {
+    return new TestCommandLineOptionsBuilder()
+        .set("--plugin-linea-extra-data-pricing-enabled=", Boolean.TRUE.toString());
+  }
+
+  @Test
+  public void updateMinGasPriceViaExtraData() {
+    minerNode.getMiningParameters().setMinTransactionGasPrice(MIN_GAS_PRICE);
+    final var doubleMinGasPrice = MIN_GAS_PRICE.multiply(2);
+
+    final var extraData =
+        createExtraDataPricingField(
+            0, MIN_GAS_PRICE.toLong() / WEI_IN_KWEI, doubleMinGasPrice.toLong() / WEI_IN_KWEI);
+    final var reqSetExtraData = new ExtraDataPricingTest.MinerSetExtraDataRequest(extraData);
+    final var respSetExtraData = reqSetExtraData.execute(minerNode.nodeRequests());
+
+    assertThat(respSetExtraData).isTrue();
+
+    final Account sender = accounts.getSecondaryBenefactor();
+    final Account recipient = accounts.createAccount("recipient");
+
+    final TransferTransaction transferTx = accountTransactions.createTransfer(sender, recipient, 1);
+    final var txHash = minerNode.execute(transferTx);
+
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(txHash.toHexString()));
+
+    assertThat(minerNode.getMiningParameters().getMinTransactionGasPrice())
+        .isEqualTo(doubleMinGasPrice);
+  }
+
+  @Test
+  public void updateProfitabilityParamsViaExtraData() throws IOException {
+    final Web3j web3j = minerNode.nodeRequests().eth();
+    final Account sender = accounts.getSecondaryBenefactor();
+    final Account recipient = accounts.createAccount("recipient");
+    minerNode.getMiningParameters().setMinTransactionGasPrice(MIN_GAS_PRICE);
+
+    final var extraData =
+        createExtraDataPricingField(
+            MIN_GAS_PRICE.multiply(2).toLong() / WEI_IN_KWEI,
+            MIN_GAS_PRICE.toLong() / WEI_IN_KWEI,
+            MIN_GAS_PRICE.toLong() / WEI_IN_KWEI);
+    final var reqSetExtraData = new ExtraDataPricingTest.MinerSetExtraDataRequest(extraData);
+    final var respSetExtraData = reqSetExtraData.execute(minerNode.nodeRequests());
+
+    assertThat(respSetExtraData).isTrue();
+
+    // when this first tx is mined the above extra data pricing will have effect on following txs
+    final TransferTransaction profitableTx =
+        accountTransactions.createTransfer(sender, recipient, 1);
+    final var protitableTx = minerNode.execute(profitableTx);
+
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(protitableTx.toHexString()));
+
+    // this tx will be evaluated with the previously set extra data pricing to be unprofitable
+    final RawTransaction unprofitableTx =
+        RawTransaction.createTransaction(
+            BigInteger.ZERO,
+            MIN_GAS_PRICE.getAsBigInteger(),
+            BigInteger.valueOf(21000),
+            recipient.getAddress(),
+            "");
+
+    final byte[] signedUnprofitableTx =
+        TransactionEncoder.signMessage(
+            unprofitableTx, Credentials.create(Accounts.GENESIS_ACCOUNT_ONE_PRIVATE_KEY));
+
+    final EthSendTransaction signedUnprofitableTxResp =
+        web3j.ethSendRawTransaction(Numeric.toHexString(signedUnprofitableTx)).send();
+
+    assertThat(signedUnprofitableTxResp.hasError()).isTrue();
+    assertThat(signedUnprofitableTxResp.getError().getMessage()).isEqualTo("Gas price too low");
+
+    assertThat(getTxPoolContent()).isEmpty();
+  }
+
+  static class MinerSetExtraDataRequest implements Transaction<Boolean> {
+    private final Bytes32 extraData;
+
+    public MinerSetExtraDataRequest(final Bytes32 extraData) {
+      this.extraData = extraData;
+    }
+
+    @Override
+    public Boolean execute(final NodeRequests nodeRequests) {
+      try {
+        return new Request<>(
+                "miner_setExtraData",
+                List.of(extraData.toHexString()),
+                nodeRequests.getWeb3jService(),
+                MinerSetExtraDataResponse.class)
+            .send()
+            .getResult();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    static class MinerSetExtraDataResponse extends org.web3j.protocol.core.Response<Boolean> {}
+  }
+
+  private Bytes32 createExtraDataPricingField(
+      final long fixedCostKWei, final long variableCostKWei, final long minGasPriceKWei) {
+    final UInt32 fixed = UInt32.valueOf(BigInteger.valueOf(fixedCostKWei));
+    final UInt32 variable = UInt32.valueOf(BigInteger.valueOf(variableCostKWei));
+    final UInt32 min = UInt32.valueOf(BigInteger.valueOf(minGasPriceKWei));
+
+    return Bytes32.rightPad(
+        Bytes.concatenate(Bytes.of((byte) 1), fixed.toBytes(), variable.toBytes(), min.toBytes()));
+  }
+}

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasCompatibilityModeTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasCompatibilityModeTest.java
@@ -40,7 +40,6 @@ public class EstimateGasCompatibilityModeTest extends EstimateGasTest {
   protected void assertIsProfitable(
       final Transaction tx,
       final Wei baseFee,
-      final Wei estimatedPriorityFee,
       final Wei estimatedMaxGasPrice,
       final long estimatedGasLimit) {
     final var minGasPrice = minerNode.getMiningParameters().getMinTransactionGasPrice();
@@ -62,6 +61,6 @@ public class EstimateGasCompatibilityModeTest extends EstimateGasTest {
   protected void assertMinGasPriceLowerBound(final Wei baseFee, final Wei estimatedMaxGasPrice) {
     // since we are in compatibility mode, we want to check that returned profitable priority fee is
     // the min priority fee per gas * multiplier + base fee
-    assertIsProfitable(null, baseFee, null, estimatedMaxGasPrice, 0);
+    assertIsProfitable(null, baseFee, estimatedMaxGasPrice, 0);
   }
 }

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -158,7 +158,7 @@ public class EstimateGasTest extends LineaPluginTestBase {
 
     final var profitablePriorityFee =
         profitabilityCalculator.profitablePriorityFeePerGas(
-            tx, profitabilityConf.txPoolMinMargin(), estimatedGasLimit);
+            tx, profitabilityConf.txPoolMinMargin(), estimatedGasLimit, minGasPrice);
 
     assertThat(profitablePriorityFee.greaterThan(minGasPrice)).isTrue();
 
@@ -168,7 +168,8 @@ public class EstimateGasTest extends LineaPluginTestBase {
                 tx,
                 profitabilityConf.txPoolMinMargin(),
                 estimatedMaxGasPrice,
-                estimatedGasLimit))
+                estimatedGasLimit,
+                minGasPrice))
         .isTrue();
   }
 

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -141,13 +141,12 @@ public class EstimateGasTest extends LineaPluginTestBase {
             .signature(LineaEstimateGas.FAKE_SIGNATURE_FOR_SIZE_CALCULATION)
             .build();
 
-    assertIsProfitable(tx, baseFee, estimatedPriorityFee, estimatedMaxGasPrice, estimatedGasLimit);
+    assertIsProfitable(tx, baseFee, estimatedMaxGasPrice, estimatedGasLimit);
   }
 
   protected void assertIsProfitable(
       final org.hyperledger.besu.ethereum.core.Transaction tx,
       final Wei baseFee,
-      final Wei estimatedPriorityFee,
       final Wei estimatedMaxGasPrice,
       final long estimatedGasLimit) {
 
@@ -155,17 +154,13 @@ public class EstimateGasTest extends LineaPluginTestBase {
 
     final var profitabilityCalculator = new TransactionProfitabilityCalculator(profitabilityConf);
 
-    final var profitablePriorityFee =
-        profitabilityCalculator.profitablePriorityFeePerGas(
-            tx, profitabilityConf.txPoolMinMargin(), estimatedGasLimit, minGasPrice);
-
-    assertThat(profitablePriorityFee.greaterThan(minGasPrice)).isTrue();
+    assertThat(estimatedMaxGasPrice.greaterOrEqualThan(minGasPrice)).isTrue();
 
     assertThat(
             profitabilityCalculator.isProfitable(
                 "Test",
                 tx,
-                profitabilityConf.txPoolMinMargin(),
+                profitabilityConf.estimateGasMinMargin(),
                 estimatedMaxGasPrice,
                 estimatedGasLimit,
                 minGasPrice))

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -45,12 +45,11 @@ import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.web3j.protocol.core.Request;
-import org.web3j.protocol.core.Response;
 import org.web3j.protocol.http.HttpService;
 
 public class EstimateGasTest extends LineaPluginTestBase {
-  protected static final int FIXED_GAS_COST_KWEI = 1_200_000;
-  protected static final int VARIABLE_GAS_COST_KWEI = 90_000;
+  protected static final int FIXED_GAS_COST_WEI = 0;
+  protected static final int VARIABLE_GAS_COST_WEI = 1_000_000_000;
   protected static final double MIN_MARGIN = 1.0;
   protected static final double ESTIMATE_GAS_MIN_MARGIN = 1.0;
   protected static final Wei MIN_GAS_PRICE = Wei.of(1_000_000_000);
@@ -64,8 +63,8 @@ public class EstimateGasTest extends LineaPluginTestBase {
 
   protected TestCommandLineOptionsBuilder getTestCommandLineOptionsBuilder() {
     return new TestCommandLineOptionsBuilder()
-        .set("--plugin-linea-fixed-gas-cost-kwei=", String.valueOf(FIXED_GAS_COST_KWEI))
-        .set("--plugin-linea-variable-gas-cost-kwei=", String.valueOf(VARIABLE_GAS_COST_KWEI))
+        .set("--plugin-linea-fixed-gas-cost-wei=", String.valueOf(FIXED_GAS_COST_WEI))
+        .set("--plugin-linea-variable-gas-cost-wei=", String.valueOf(VARIABLE_GAS_COST_WEI))
         .set("--plugin-linea-min-margin=", String.valueOf(MIN_MARGIN))
         .set("--plugin-linea-estimate-gas-min-margin=", String.valueOf(ESTIMATE_GAS_MIN_MARGIN))
         .set("--plugin-linea-max-tx-gas-limit=", String.valueOf(MAX_TRANSACTION_GAS_LIMIT));
@@ -80,8 +79,8 @@ public class EstimateGasTest extends LineaPluginTestBase {
   public void createDefaultConfigurations() {
     profitabilityConf =
         LineaProfitabilityCliOptions.create().toDomainObject().toBuilder()
-            .fixedCostKWei(FIXED_GAS_COST_KWEI)
-            .variableCostKWei(VARIABLE_GAS_COST_KWEI)
+            .fixedCostWei(FIXED_GAS_COST_WEI)
+            .variableCostWei(VARIABLE_GAS_COST_WEI)
             .minMargin(MIN_MARGIN)
             .estimateGasMinMargin(ESTIMATE_GAS_MIN_MARGIN)
             .build();

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -49,9 +49,8 @@ import org.web3j.protocol.core.Response;
 import org.web3j.protocol.http.HttpService;
 
 public class EstimateGasTest extends LineaPluginTestBase {
-  protected static final int VERIFICATION_GAS_COST = 1_200_000;
-  protected static final int VERIFICATION_CAPACITY = 90_000;
-  protected static final int GAS_PRICE_RATIO = 15;
+  protected static final int FIXED_GAS_COST_KWEI = 1_200_000;
+  protected static final int VARIABLE_GAS_COST_KWEI = 90_000;
   protected static final double MIN_MARGIN = 1.0;
   protected static final double ESTIMATE_GAS_MIN_MARGIN = 1.0;
   protected static final Wei MIN_GAS_PRICE = Wei.of(1_000_000_000);
@@ -65,9 +64,8 @@ public class EstimateGasTest extends LineaPluginTestBase {
 
   protected TestCommandLineOptionsBuilder getTestCommandLineOptionsBuilder() {
     return new TestCommandLineOptionsBuilder()
-        .set("--plugin-linea-verification-gas-cost=", String.valueOf(VERIFICATION_GAS_COST))
-        .set("--plugin-linea-verification-capacity=", String.valueOf(VERIFICATION_CAPACITY))
-        .set("--plugin-linea-gas-price-ratio=", String.valueOf(GAS_PRICE_RATIO))
+        .set("--plugin-linea-fixed-gas-cost-kwei=", String.valueOf(FIXED_GAS_COST_KWEI))
+        .set("--plugin-linea-variable-gas-cost-kwei=", String.valueOf(VARIABLE_GAS_COST_KWEI))
         .set("--plugin-linea-min-margin=", String.valueOf(MIN_MARGIN))
         .set("--plugin-linea-estimate-gas-min-margin=", String.valueOf(ESTIMATE_GAS_MIN_MARGIN))
         .set("--plugin-linea-max-tx-gas-limit=", String.valueOf(MAX_TRANSACTION_GAS_LIMIT));
@@ -82,9 +80,8 @@ public class EstimateGasTest extends LineaPluginTestBase {
   public void createDefaultConfigurations() {
     profitabilityConf =
         LineaProfitabilityCliOptions.create().toDomainObject().toBuilder()
-            .verificationCapacity(VERIFICATION_CAPACITY)
-            .verificationGasCost(VERIFICATION_GAS_COST)
-            .gasPriceRatio(GAS_PRICE_RATIO)
+            .fixedCostKWei(FIXED_GAS_COST_KWEI)
+            .variableCostKWei(VARIABLE_GAS_COST_KWEI)
             .minMargin(MIN_MARGIN)
             .estimateGasMinMargin(ESTIMATE_GAS_MIN_MARGIN)
             .build();
@@ -161,7 +158,7 @@ public class EstimateGasTest extends LineaPluginTestBase {
 
     final var profitablePriorityFee =
         profitabilityCalculator.profitablePriorityFeePerGas(
-            tx, profitabilityConf.txPoolMinMargin(), minGasPrice, estimatedGasLimit);
+            tx, profitabilityConf.txPoolMinMargin(), estimatedGasLimit);
 
     assertThat(profitablePriorityFee.greaterThan(minGasPrice)).isTrue();
 
@@ -170,7 +167,6 @@ public class EstimateGasTest extends LineaPluginTestBase {
                 "Test",
                 tx,
                 profitabilityConf.txPoolMinMargin(),
-                minerNode.getMiningParameters().getMinTransactionGasPrice(),
                 estimatedMaxGasPrice,
                 estimatedGasLimit))
         .isTrue();

--- a/acceptance-tests/src/test/java/org/hyperledger/besu/tests/acceptance/dsl/BlockUtils.java
+++ b/acceptance-tests/src/test/java/org/hyperledger/besu/tests/acceptance/dsl/BlockUtils.java
@@ -67,7 +67,6 @@ public class BlockUtils {
         null,
         null,
         null,
-        null,
         blockHeaderFunctions);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/bl/TransactionProfitabilityCalculator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/bl/TransactionProfitabilityCalculator.java
@@ -14,8 +14,6 @@
  */
 package net.consensys.linea.bl;
 
-import static net.consensys.linea.config.LineaProfitabilityConfiguration.WEI_IN_KWEI;
-
 import java.math.BigDecimal;
 
 import lombok.extern.slf4j.Slf4j;
@@ -41,25 +39,24 @@ public class TransactionProfitabilityCalculator {
       final Wei minGasPriceWei) {
     final int compressedTxSize = getCompressedTxSize(transaction);
 
-    final long variableCostKWei =
+    final long variableCostWei =
         profitabilityConf.extraDataPricingEnabled()
-            ? profitabilityConf.variableCostKWei()
-            : minGasPriceWei.divide(WEI_IN_KWEI).toLong();
+            ? profitabilityConf.variableCostWei()
+            : minGasPriceWei.toLong();
 
-    final var profitAtKWei =
-        minMargin * (variableCostKWei * compressedTxSize / gas + profitabilityConf.fixedCostKWei());
+    final var profitAt =
+        minMargin * (variableCostWei * compressedTxSize / gas + profitabilityConf.fixedCostWei());
 
-    final var profitAtWei =
-        Wei.ofNumber(BigDecimal.valueOf(profitAtKWei).toBigInteger()).multiply(WEI_IN_KWEI);
+    final var profitAtWei = Wei.ofNumber(BigDecimal.valueOf(profitAt).toBigInteger());
 
     log.atDebug()
         .setMessage(
-            "Estimated profitable priorityFeePerGas: {}; minMargin={}, fixedCostKWei={}, "
-                + "variableCostKWei={}, gas={}, txSize={}, compressedTxSize={}")
+            "Estimated profitable priorityFeePerGas: {}; minMargin={}, fixedCostWei={}, "
+                + "variableCostWei={}, gas={}, txSize={}, compressedTxSize={}")
         .addArgument(profitAtWei::toHumanReadableString)
         .addArgument(minMargin)
-        .addArgument(profitabilityConf.fixedCostKWei())
-        .addArgument(variableCostKWei)
+        .addArgument(profitabilityConf.fixedCostWei())
+        .addArgument(variableCostWei)
         .addArgument(gas)
         .addArgument(transaction::getSize)
         .addArgument(compressedTxSize)
@@ -121,7 +118,7 @@ public class TransactionProfitabilityCalculator {
 
     leb.setMessage(
             "Context {}. Transaction {} has a margin of {}, minMargin={}, effectiveGasPrice={},"
-                + " profitableGasPrice={}, fixedCostKWei={}, variableCostKWei={}, "
+                + " profitableGasPrice={}, fixedCostWei={}, variableCostWei={}, "
                 + " gasUsed={}")
         .addArgument(context)
         .addArgument(transaction::getHash)
@@ -132,12 +129,12 @@ public class TransactionProfitabilityCalculator {
         .addArgument(minMargin)
         .addArgument(effectiveGasPrice::toHumanReadableString)
         .addArgument(profitableGasPrice::toHumanReadableString)
-        .addArgument(profitabilityConf.fixedCostKWei())
+        .addArgument(profitabilityConf.fixedCostWei())
         .addArgument(
             () ->
                 profitabilityConf.extraDataPricingEnabled()
-                    ? profitabilityConf.variableCostKWei()
-                    : minGasPriceWei.divide(WEI_IN_KWEI).toLong())
+                    ? profitabilityConf.variableCostWei()
+                    : minGasPriceWei.toLong())
         .addArgument(gasUsed)
         .log();
   }

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
@@ -23,11 +23,11 @@ import picocli.CommandLine;
 
 /** The Linea profitability calculator CLI options. */
 public class LineaProfitabilityCliOptions {
-  public static final String FIXED_GAS_COST_KWEI = "--plugin-linea-fixed-gas-cost-kwei";
-  public static final long DEFAULT_FIXED_GAS_COST_KWEI = 0;
+  public static final String FIXED_GAS_COST_WEI = "--plugin-linea-fixed-gas-cost-wei";
+  public static final long DEFAULT_FIXED_GAS_COST_WEI = 0;
 
-  public static final String VARIABLE_GAS_COST_KWEI = "--plugin-linea-variable-gas-cost-kwei";
-  public static final long DEFAULT_VARIABLE_GAS_COST_KWEI = 1_000_000;
+  public static final String VARIABLE_GAS_COST_WEI = "--plugin-linea-variable-gas-cost-wei";
+  public static final long DEFAULT_VARIABLE_GAS_COST_WEI = 1_000_000_000;
 
   public static final String MIN_MARGIN = "--plugin-linea-min-margin";
   public static final BigDecimal DEFAULT_MIN_MARGIN = BigDecimal.ONE;
@@ -52,19 +52,19 @@ public class LineaProfitabilityCliOptions {
 
   @Positive
   @CommandLine.Option(
-      names = {FIXED_GAS_COST_KWEI},
+      names = {FIXED_GAS_COST_WEI},
       hidden = true,
       paramLabel = "<INTEGER>",
-      description = "Fixed gas cost in KWei (default: ${DEFAULT-VALUE})")
-  private long fixedGasCostKwei = DEFAULT_FIXED_GAS_COST_KWEI;
+      description = "Fixed gas cost in Wei (default: ${DEFAULT-VALUE})")
+  private long fixedGasCostWei = DEFAULT_FIXED_GAS_COST_WEI;
 
   @Positive
   @CommandLine.Option(
-      names = {VARIABLE_GAS_COST_KWEI},
+      names = {VARIABLE_GAS_COST_WEI},
       hidden = true,
       paramLabel = "<INTEGER>",
-      description = "Variable gas cost in KWei (default: ${DEFAULT-VALUE})")
-  private long variableGasCostKwei = DEFAULT_VARIABLE_GAS_COST_KWEI;
+      description = "Variable gas cost in Wei (default: ${DEFAULT-VALUE})")
+  private long variableGasCostWei = DEFAULT_VARIABLE_GAS_COST_WEI;
 
   @Positive
   @CommandLine.Option(
@@ -139,8 +139,8 @@ public class LineaProfitabilityCliOptions {
   public static LineaProfitabilityCliOptions fromConfig(
       final LineaProfitabilityConfiguration config) {
     final LineaProfitabilityCliOptions options = create();
-    options.fixedGasCostKwei = config.fixedCostKWei();
-    options.variableGasCostKwei = config.variableCostKWei();
+    options.fixedGasCostWei = config.fixedCostWei();
+    options.variableGasCostWei = config.variableCostWei();
     options.minMargin = BigDecimal.valueOf(config.minMargin());
     options.estimageGasMinMargin = BigDecimal.valueOf(config.estimateGasMinMargin());
     options.txPoolMinMargin = BigDecimal.valueOf(config.txPoolMinMargin());
@@ -157,8 +157,8 @@ public class LineaProfitabilityCliOptions {
    */
   public LineaProfitabilityConfiguration toDomainObject() {
     return LineaProfitabilityConfiguration.builder()
-        .fixedCostKWei(fixedGasCostKwei)
-        .variableCostKWei(variableGasCostKwei)
+        .fixedCostWei(fixedGasCostWei)
+        .variableCostWei(variableGasCostWei)
         .minMargin(minMargin.doubleValue())
         .estimateGasMinMargin(estimageGasMinMargin.doubleValue())
         .txPoolMinMargin(txPoolMinMargin.doubleValue())
@@ -171,8 +171,8 @@ public class LineaProfitabilityCliOptions {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add(FIXED_GAS_COST_KWEI, fixedGasCostKwei)
-        .add(VARIABLE_GAS_COST_KWEI, variableGasCostKwei)
+        .add(FIXED_GAS_COST_WEI, fixedGasCostWei)
+        .add(VARIABLE_GAS_COST_WEI, variableGasCostWei)
         .add(MIN_MARGIN, minMargin)
         .add(ESTIMATE_GAS_MIN_MARGIN, estimageGasMinMargin)
         .add(TX_POOL_MIN_MARGIN, txPoolMinMargin)

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
@@ -46,6 +46,10 @@ public class LineaProfitabilityCliOptions {
       "--plugin-linea-tx-pool-profitability-check-p2p-enabled";
   public static final boolean DEFAULT_TX_POOL_ENABLE_CHECK_P2P = false;
 
+  public static final String EXTRA_DATA_PRICING_ENABLED =
+      "--plugin-linea-extra-dataPricing-enabled";
+  public static final boolean DEFAULT_EXTRA_DATA_PRICING_ENABLED = false;
+
   @Positive
   @CommandLine.Option(
       names = {FIXED_GAS_COST_KWEI},
@@ -106,6 +110,15 @@ public class LineaProfitabilityCliOptions {
           "Enable the profitability check for txs received via p2p? (default: ${DEFAULT-VALUE})")
   private boolean txPoolCheckP2pEnabled = DEFAULT_TX_POOL_ENABLE_CHECK_P2P;
 
+  @CommandLine.Option(
+      names = {EXTRA_DATA_PRICING_ENABLED},
+      arity = "0..1",
+      hidden = true,
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Enable setting pricing parameters via extra data field (default: ${DEFAULT-VALUE})")
+  private boolean extraDataPricingEnabled = DEFAULT_EXTRA_DATA_PRICING_ENABLED;
+
   private LineaProfitabilityCliOptions() {}
 
   /**
@@ -133,6 +146,7 @@ public class LineaProfitabilityCliOptions {
     options.txPoolMinMargin = BigDecimal.valueOf(config.txPoolMinMargin());
     options.txPoolCheckApiEnabled = config.txPoolCheckApiEnabled();
     options.txPoolCheckP2pEnabled = config.txPoolCheckP2pEnabled();
+    options.extraDataPricingEnabled = config.extraDataPricingEnabled();
     return options;
   }
 
@@ -150,6 +164,7 @@ public class LineaProfitabilityCliOptions {
         .txPoolMinMargin(txPoolMinMargin.doubleValue())
         .txPoolCheckApiEnabled(txPoolCheckApiEnabled)
         .txPoolCheckP2pEnabled(txPoolCheckP2pEnabled)
+        .extraDataPricingEnabled(extraDataPricingEnabled)
         .build();
   }
 
@@ -163,6 +178,7 @@ public class LineaProfitabilityCliOptions {
         .add(TX_POOL_MIN_MARGIN, txPoolMinMargin)
         .add(TX_POOL_ENABLE_CHECK_API, txPoolCheckApiEnabled)
         .add(TX_POOL_ENABLE_CHECK_P2P, txPoolCheckP2pEnabled)
+        .add(EXTRA_DATA_PRICING_ENABLED, extraDataPricingEnabled)
         .toString();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
@@ -19,23 +19,15 @@ import java.math.BigDecimal;
 
 import com.google.common.base.MoreObjects;
 import jakarta.validation.constraints.Positive;
-import net.consensys.linea.config.converters.WeiConverter;
-import org.hyperledger.besu.datatypes.Wei;
 import picocli.CommandLine;
 
 /** The Linea profitability calculator CLI options. */
 public class LineaProfitabilityCliOptions {
-  public static final String VERIFICATION_GAS_COST = "--plugin-linea-verification-gas-cost";
-  public static final int DEFAULT_VERIFICATION_GAS_COST = 1_200_000;
+  public static final String FIXED_GAS_COST_KWEI = "--plugin-linea-fixed-gas-cost-kwei";
+  public static final long DEFAULT_FIXED_GAS_COST_KWEI = 1_200_000;
 
-  public static final String VERIFICATION_CAPACITY = "--plugin-linea-verification-capacity";
-  public static final int DEFAULT_VERIFICATION_CAPACITY = 90_000;
-
-  public static final String GAS_PRICE_RATIO = "--plugin-linea-gas-price-ratio";
-  public static final int DEFAULT_GAS_PRICE_RATIO = 15;
-
-  public static final String GAS_PRICE_ADJUSTMENT = "--plugin-linea-gas-price-adjustment";
-  public static final Wei DEFAULT_GAS_PRICE_ADJUSTMENT = Wei.ZERO;
+  public static final String VARIABLE_GAS_COST_KWEI = "--plugin-linea-variable-gas-cost-kwei";
+  public static final long DEFAULT_VARIABLE_GAS_COST_KWEI = 90_000;
 
   public static final String MIN_MARGIN = "--plugin-linea-min-margin";
   public static final BigDecimal DEFAULT_MIN_MARGIN = BigDecimal.ONE;
@@ -56,36 +48,19 @@ public class LineaProfitabilityCliOptions {
 
   @Positive
   @CommandLine.Option(
-      names = {VERIFICATION_GAS_COST},
+      names = {FIXED_GAS_COST_KWEI},
       hidden = true,
       paramLabel = "<INTEGER>",
-      description = "L1 verification gas cost (default: ${DEFAULT-VALUE})")
-  private int verificationGasCost = DEFAULT_VERIFICATION_GAS_COST;
+      description = "Fixed gas cost in KWei (default: ${DEFAULT-VALUE})")
+  private long fixedGasCostKwei = DEFAULT_FIXED_GAS_COST_KWEI;
 
   @Positive
   @CommandLine.Option(
-      names = {VERIFICATION_CAPACITY},
+      names = {VARIABLE_GAS_COST_KWEI},
       hidden = true,
       paramLabel = "<INTEGER>",
-      description = "L1 verification capacity (default: ${DEFAULT-VALUE})")
-  private int verificationCapacity = DEFAULT_VERIFICATION_CAPACITY;
-
-  @Positive
-  @CommandLine.Option(
-      names = {GAS_PRICE_RATIO},
-      hidden = true,
-      paramLabel = "<INTEGER>",
-      description = "L1/L2 gas price ratio (default: ${DEFAULT-VALUE})")
-  private int gasPriceRatio = DEFAULT_GAS_PRICE_RATIO;
-
-  @CommandLine.Option(
-      names = {GAS_PRICE_ADJUSTMENT},
-      hidden = true,
-      converter = WeiConverter.class,
-      paramLabel = "<WEI>",
-      description =
-          "Amount to add to the calculated profitable gas price (default: ${DEFAULT-VALUE})")
-  private Wei gasPriceAdjustment = DEFAULT_GAS_PRICE_ADJUSTMENT;
+      description = "Variable gas cost in KWei (default: ${DEFAULT-VALUE})")
+  private long variableGasCostKwei = DEFAULT_VARIABLE_GAS_COST_KWEI;
 
   @Positive
   @CommandLine.Option(
@@ -151,10 +126,8 @@ public class LineaProfitabilityCliOptions {
   public static LineaProfitabilityCliOptions fromConfig(
       final LineaProfitabilityConfiguration config) {
     final LineaProfitabilityCliOptions options = create();
-    options.verificationGasCost = config.verificationGasCost();
-    options.verificationCapacity = config.verificationCapacity();
-    options.gasPriceRatio = config.gasPriceRatio();
-    options.gasPriceAdjustment = config.gasPriceAdjustment();
+    options.fixedGasCostKwei = config.fixedCostKWei();
+    options.variableGasCostKwei = config.variableCostKWei();
     options.minMargin = BigDecimal.valueOf(config.minMargin());
     options.estimageGasMinMargin = BigDecimal.valueOf(config.estimateGasMinMargin());
     options.txPoolMinMargin = BigDecimal.valueOf(config.txPoolMinMargin());
@@ -170,10 +143,8 @@ public class LineaProfitabilityCliOptions {
    */
   public LineaProfitabilityConfiguration toDomainObject() {
     return LineaProfitabilityConfiguration.builder()
-        .verificationGasCost(verificationGasCost)
-        .verificationCapacity(verificationCapacity)
-        .gasPriceRatio(gasPriceRatio)
-        .gasPriceAdjustment(gasPriceAdjustment)
+        .fixedCostKWei(fixedGasCostKwei)
+        .variableCostKWei(variableGasCostKwei)
         .minMargin(minMargin.doubleValue())
         .estimateGasMinMargin(estimageGasMinMargin.doubleValue())
         .txPoolMinMargin(txPoolMinMargin.doubleValue())
@@ -185,10 +156,8 @@ public class LineaProfitabilityCliOptions {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add(VERIFICATION_GAS_COST, verificationGasCost)
-        .add(VERIFICATION_CAPACITY, verificationCapacity)
-        .add(GAS_PRICE_RATIO, gasPriceRatio)
-        .add(GAS_PRICE_ADJUSTMENT, gasPriceAdjustment)
+        .add(FIXED_GAS_COST_KWEI, fixedGasCostKwei)
+        .add(VARIABLE_GAS_COST_KWEI, variableGasCostKwei)
         .add(MIN_MARGIN, minMargin)
         .add(ESTIMATE_GAS_MIN_MARGIN, estimageGasMinMargin)
         .add(TX_POOL_MIN_MARGIN, txPoolMinMargin)

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
@@ -47,7 +47,7 @@ public class LineaProfitabilityCliOptions {
   public static final boolean DEFAULT_TX_POOL_ENABLE_CHECK_P2P = false;
 
   public static final String EXTRA_DATA_PRICING_ENABLED =
-      "--plugin-linea-extra-dataPricing-enabled";
+      "--plugin-linea-extra-data-pricing-enabled";
   public static final boolean DEFAULT_EXTRA_DATA_PRICING_ENABLED = false;
 
   @Positive

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityCliOptions.java
@@ -24,10 +24,10 @@ import picocli.CommandLine;
 /** The Linea profitability calculator CLI options. */
 public class LineaProfitabilityCliOptions {
   public static final String FIXED_GAS_COST_KWEI = "--plugin-linea-fixed-gas-cost-kwei";
-  public static final long DEFAULT_FIXED_GAS_COST_KWEI = 1_200_000;
+  public static final long DEFAULT_FIXED_GAS_COST_KWEI = 0;
 
   public static final String VARIABLE_GAS_COST_KWEI = "--plugin-linea-variable-gas-cost-kwei";
-  public static final long DEFAULT_VARIABLE_GAS_COST_KWEI = 90_000;
+  public static final long DEFAULT_VARIABLE_GAS_COST_KWEI = 1_000_000;
 
   public static final String MIN_MARGIN = "--plugin-linea-min-margin";
   public static final BigDecimal DEFAULT_MIN_MARGIN = BigDecimal.ONE;

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
@@ -16,17 +16,22 @@
 package net.consensys.linea.config;
 
 import lombok.Builder;
-import org.hyperledger.besu.datatypes.Wei;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 
 /** The Linea profitability calculator configuration. */
 @Builder(toBuilder = true)
-public record LineaProfitabilityConfiguration(
-    int verificationGasCost,
-    int verificationCapacity,
-    int gasPriceRatio,
-    Wei gasPriceAdjustment,
-    double minMargin,
-    double estimateGasMinMargin,
-    double txPoolMinMargin,
-    boolean txPoolCheckApiEnabled,
-    boolean txPoolCheckP2pEnabled) {}
+@Accessors(fluent = true)
+@Getter
+@ToString
+public class LineaProfitabilityConfiguration {
+  @Setter private volatile long fixedCostKWei;
+  @Setter private volatile long variableCostKWei;
+  double minMargin;
+  double estimateGasMinMargin;
+  double txPoolMinMargin;
+  boolean txPoolCheckApiEnabled;
+  boolean txPoolCheckP2pEnabled;
+}

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
@@ -17,7 +17,6 @@ package net.consensys.linea.config;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
@@ -27,11 +26,31 @@ import lombok.experimental.Accessors;
 @Getter
 @ToString
 public class LineaProfitabilityConfiguration {
-  @Setter private volatile long fixedCostKWei;
-  @Setter private volatile long variableCostKWei;
-  double minMargin;
-  double estimateGasMinMargin;
-  double txPoolMinMargin;
-  boolean txPoolCheckApiEnabled;
-  boolean txPoolCheckP2pEnabled;
+  private long fixedCostKWei;
+  private long variableCostKWei;
+  private double minMargin;
+  private double estimateGasMinMargin;
+  private double txPoolMinMargin;
+  private boolean txPoolCheckApiEnabled;
+  private boolean txPoolCheckP2pEnabled;
+
+  /**
+   * These 2 parameters must be atomically updated
+   *
+   * @param fixedCostKWei fixed cost in KWei
+   * @param variableCostKWei variable cost in KWei
+   */
+  public synchronized void updateFixedAndVariableCost(
+      final long fixedCostKWei, final long variableCostKWei) {
+    this.fixedCostKWei = fixedCostKWei;
+    this.variableCostKWei = variableCostKWei;
+  }
+
+  public synchronized long fixedCostKWei() {
+    return fixedCostKWei;
+  }
+
+  public synchronized long variableCostKWei() {
+    return variableCostKWei;
+  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
@@ -33,6 +33,7 @@ public class LineaProfitabilityConfiguration {
   private double txPoolMinMargin;
   private boolean txPoolCheckApiEnabled;
   private boolean txPoolCheckP2pEnabled;
+  private boolean extraDataPricingEnabled;
 
   /**
    * These 2 parameters must be atomically updated

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
@@ -26,6 +26,8 @@ import lombok.experimental.Accessors;
 @Getter
 @ToString
 public class LineaProfitabilityConfiguration {
+  public static final int WEI_IN_KWEI = 1_000;
+
   private long fixedCostKWei;
   private long variableCostKWei;
   private double minMargin;

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaProfitabilityConfiguration.java
@@ -26,10 +26,11 @@ import lombok.experimental.Accessors;
 @Getter
 @ToString
 public class LineaProfitabilityConfiguration {
-  public static final int WEI_IN_KWEI = 1_000;
+  /** It is safe to keep this as long, since it will store value <= max_int * 1000 */
+  private long fixedCostWei;
+  /** It is safe to keep this as long, since it will store value <= max_int * 1000 */
+  private long variableCostWei;
 
-  private long fixedCostKWei;
-  private long variableCostKWei;
   private double minMargin;
   private double estimateGasMinMargin;
   private double txPoolMinMargin;
@@ -40,20 +41,20 @@ public class LineaProfitabilityConfiguration {
   /**
    * These 2 parameters must be atomically updated
    *
-   * @param fixedCostKWei fixed cost in KWei
-   * @param variableCostKWei variable cost in KWei
+   * @param fixedCostWei fixed cost in Wei
+   * @param variableCostWei variable cost in Wei
    */
   public synchronized void updateFixedAndVariableCost(
-      final long fixedCostKWei, final long variableCostKWei) {
-    this.fixedCostKWei = fixedCostKWei;
-    this.variableCostKWei = variableCostKWei;
+      final long fixedCostWei, final long variableCostWei) {
+    this.fixedCostWei = fixedCostWei;
+    this.variableCostWei = variableCostWei;
   }
 
-  public synchronized long fixedCostKWei() {
-    return fixedCostKWei;
+  public synchronized long fixedCostWei() {
+    return fixedCostWei;
   }
 
-  public synchronized long variableCostKWei() {
-    return variableCostKWei;
+  public synchronized long variableCostWei() {
+    return variableCostWei;
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaRpcConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaRpcConfiguration.java
@@ -18,8 +18,17 @@ package net.consensys.linea.config;
 import java.math.BigDecimal;
 
 import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 
 /** The Linea RPC configuration. */
 @Builder(toBuilder = true)
-public record LineaRpcConfiguration(
-    boolean estimateGasCompatibilityModeEnabled, BigDecimal estimateGasCompatibilityMultiplier) {}
+@Accessors(fluent = true)
+@Getter
+@ToString
+public class LineaRpcConfiguration {
+  @Setter private volatile boolean estimateGasCompatibilityModeEnabled;
+  private BigDecimal estimateGasCompatibilityMultiplier;
+}

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
@@ -15,8 +15,6 @@
 
 package net.consensys.linea.extradata;
 
-import static net.consensys.linea.config.LineaProfitabilityConfiguration.WEI_IN_KWEI;
-
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -83,6 +81,7 @@ public class LineaExtraDataHandler implements BesuEvents.BlockAddedListener {
 
   @SuppressWarnings("rawtypes")
   private class Version1Parser implements ExtraDataParser {
+    private static final int WEI_IN_KWEI = 1_000;
     private final LineaProfitabilityConfiguration profitabilityConf;
     private final FieldConsumer[] fieldsSequence;
     private final MutableLong currFixedCostKWei = new MutableLong();
@@ -117,7 +116,8 @@ public class LineaExtraDataHandler implements BesuEvents.BlockAddedListener {
       }
 
       profitabilityConf.updateFixedAndVariableCost(
-          currFixedCostKWei.longValue(), currVariableCostKWei.longValue());
+          currFixedCostKWei.longValue() * WEI_IN_KWEI,
+          currVariableCostKWei.longValue() * WEI_IN_KWEI);
     }
 
     void updateMinGasPrice(final Long minGasPriceKWei) {

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.extradata;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.plugin.data.AddedBlockContext;
+import org.hyperledger.besu.plugin.services.BesuEvents;
+
+@Slf4j
+public class LineaExtraDataHandler implements BesuEvents.BlockAddedListener {
+  @Override
+  public void onBlockAdded(final AddedBlockContext addedBlockContext) {
+    final var blockHeader = addedBlockContext.getBlockHeader();
+    final var extraData = blockHeader.getExtraData();
+
+    if (!Bytes.EMPTY.equals(extraData)) {
+      final byte version = extractVersion(extraData);
+      switch (version) {
+        case 1:
+          parseVersion1(extraData);
+          break;
+        default:
+          log.warn(
+              "unsupported extra data version: {}, raw extra data field",
+              version,
+              extraData.toHexString());
+      }
+    }
+  }
+
+  private void parseVersion1(final Bytes extraData) {
+    log.info("Found extra data version 1: {}", extraData.toHexString());
+  }
+
+  private byte extractVersion(final Bytes extraData) {
+    return extraData.get(0);
+  }
+}

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
-import net.consensys.linea.config.LineaRpcConfiguration;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt32;
@@ -40,10 +39,9 @@ public class LineaExtraDataHandler implements BesuEvents.BlockAddedListener {
   public LineaExtraDataHandler(
       final RpcEndpointService rpcEndpointService,
       final BlockchainService blockchainService,
-      final LineaProfitabilityConfiguration profitabilityConf,
-      final LineaRpcConfiguration rpcConf) {
+      final LineaProfitabilityConfiguration profitabilityConf) {
     this.rpcEndpointService = rpcEndpointService;
-    extraDataParsers = new ExtraDataParser[] {new Version1Parser(profitabilityConf, rpcConf)};
+    extraDataParsers = new ExtraDataParser[] {new Version1Parser(profitabilityConf)};
     onStartup(blockchainService);
   }
 
@@ -84,16 +82,12 @@ public class LineaExtraDataHandler implements BesuEvents.BlockAddedListener {
   @SuppressWarnings("rawtypes")
   private class Version1Parser implements ExtraDataParser {
     private final LineaProfitabilityConfiguration profitabilityConf;
-    private final LineaRpcConfiguration rpcConf;
     private final FieldConsumer[] fieldsSequence;
     private final MutableLong currFixedCostKWei = new MutableLong();
     private final MutableLong currVariableCostKWei = new MutableLong();
 
-    public Version1Parser(
-        final LineaProfitabilityConfiguration profitabilityConf,
-        final LineaRpcConfiguration rpcConf) {
+    public Version1Parser(final LineaProfitabilityConfiguration profitabilityConf) {
       this.profitabilityConf = profitabilityConf;
-      this.rpcConf = rpcConf;
 
       final FieldConsumer fixedGasCostField =
           new FieldConsumer<>(
@@ -122,7 +116,6 @@ public class LineaExtraDataHandler implements BesuEvents.BlockAddedListener {
 
       profitabilityConf.updateFixedAndVariableCost(
           currFixedCostKWei.longValue(), currVariableCostKWei.longValue());
-      rpcConf.estimateGasCompatibilityModeEnabled(false);
     }
 
     void updateMinGasPrice(final Long minGasPriceKWei) {

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
@@ -15,6 +15,8 @@
 
 package net.consensys.linea.extradata;
 
+import static net.consensys.linea.config.LineaProfitabilityConfiguration.WEI_IN_KWEI;
+
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -119,7 +121,7 @@ public class LineaExtraDataHandler implements BesuEvents.BlockAddedListener {
     }
 
     void updateMinGasPrice(final Long minGasPriceKWei) {
-      final var minGasPriceWei = Wei.of(minGasPriceKWei).multiply(1000);
+      final var minGasPriceWei = Wei.of(minGasPriceKWei).multiply(WEI_IN_KWEI);
       final var resp =
           rpcEndpointService.call(
               "miner_setMinGasPrice", new Object[] {minGasPriceWei.toShortHexString()});

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
@@ -15,38 +15,97 @@
 
 package net.consensys.linea.extradata;
 
+import java.util.function.Consumer;
+import java.util.function.Function;
+
 import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.config.LineaProfitabilityConfiguration;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt32;
 import org.hyperledger.besu.plugin.data.AddedBlockContext;
 import org.hyperledger.besu.plugin.services.BesuEvents;
 
 @Slf4j
 public class LineaExtraDataHandler implements BesuEvents.BlockAddedListener {
+  private final ExtraDataParser[] extraDataParsers;
+
+  public LineaExtraDataHandler(final LineaProfitabilityConfiguration profitabilityConf) {
+    extraDataParsers = new ExtraDataParser[] {new Version1Parser(profitabilityConf)};
+  }
+
   @Override
   public void onBlockAdded(final AddedBlockContext addedBlockContext) {
     final var blockHeader = addedBlockContext.getBlockHeader();
-    final var extraData = blockHeader.getExtraData();
+    final var rawExtraData = blockHeader.getExtraData();
 
-    if (!Bytes.EMPTY.equals(extraData)) {
-      final byte version = extractVersion(extraData);
-      switch (version) {
-        case 1:
-          parseVersion1(extraData);
-          break;
-        default:
-          log.warn(
-              "unsupported extra data version: {}, raw extra data field",
-              version,
-              extraData.toHexString());
+    if (!Bytes.EMPTY.equals(rawExtraData)) {
+      for (final ExtraDataParser extraDataParser : extraDataParsers) {
+        if (extraDataParser.canParse(rawExtraData)) {
+          final var extraData = rawExtraData.slice(1);
+          extraDataParser.parse(extraData);
+          return;
+        }
       }
+      log.warn("unsupported extra data field {}", rawExtraData.toHexString());
     }
   }
 
-  private void parseVersion1(final Bytes extraData) {
-    log.info("Found extra data version 1: {}", extraData.toHexString());
+  private interface ExtraDataParser {
+    boolean canParse(Bytes extraData);
+
+    void parse(Bytes extraData);
+
+    static Long toLong(final Bytes fieldBytes) {
+      return UInt32.fromBytes(fieldBytes).toLong();
+    }
   }
 
-  private byte extractVersion(final Bytes extraData) {
-    return extraData.get(0);
+  @SuppressWarnings("rawtypes")
+  private static class Version1Parser implements ExtraDataParser {
+
+    private final FieldConsumer[] fieldsSequence;
+
+    public Version1Parser(final LineaProfitabilityConfiguration profitabilityConf) {
+      final FieldConsumer fixedGasCostField =
+          new FieldConsumer<>(
+              "fixedGasCost", 4, ExtraDataParser::toLong, profitabilityConf::fixedCostKWei);
+      final FieldConsumer variableGasCostField =
+          new FieldConsumer<>(
+              "variableGasCost", 4, ExtraDataParser::toLong, profitabilityConf::variableCostKWei);
+      final FieldConsumer minGasPriceField =
+          new FieldConsumer<>("minGasPrice", 4, ExtraDataParser::toLong, this::toDo);
+
+      this.fieldsSequence =
+          new FieldConsumer[] {fixedGasCostField, variableGasCostField, minGasPriceField};
+    }
+
+    public boolean canParse(final Bytes rawExtraData) {
+      return rawExtraData.get(0) == (byte) 1;
+    }
+
+    public void parse(final Bytes extraData) {
+      log.info("Parsing extra data version 1: {}", extraData.toHexString());
+      int startIndex = 0;
+      for (final FieldConsumer fieldConsumer : fieldsSequence) {
+        fieldConsumer.accept(extraData.slice(startIndex, fieldConsumer.length));
+        startIndex += fieldConsumer.length;
+      }
+    }
+
+    void toDo(final Long minGasPriceKWei) {
+      log.info("ToDo: call setMinGasPrice to {} kwei", minGasPriceKWei);
+    }
+  }
+
+  private record FieldConsumer<T>(
+      String name, int length, Function<Bytes, T> converter, Consumer<T> consumer)
+      implements Consumer<Bytes> {
+
+    @Override
+    public void accept(final Bytes fieldBytes) {
+      final var converted = converter.apply(fieldBytes);
+      log.debug("Field {}={} (raw bytes: {})", name, converted, fieldBytes.toHexString());
+      consumer.accept(converted);
+    }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
@@ -66,8 +66,10 @@ public class LineaExtraDataPlugin extends AbstractLineaRequiredPlugin {
   @Override
   public void start() {
     super.start();
-    besuEventsService.addBlockAddedListener(
-        new LineaExtraDataHandler(
-            rpcEndpointService, blockchainService, profitabilityConfiguration, rpcConfiguration));
+    if (profitabilityConfiguration.extraDataPricingEnabled()) {
+      besuEventsService.addBlockAddedListener(
+          new LineaExtraDataHandler(
+              rpcEndpointService, blockchainService, profitabilityConfiguration));
+    }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.extradata;
+
+import java.util.Optional;
+
+import com.google.auto.service.AutoService;
+import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.AbstractLineaRequiredPlugin;
+import org.hyperledger.besu.plugin.BesuContext;
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.services.BesuEvents;
+
+/** This plugin registers handlers that are activated when new blocks are imported */
+@Slf4j
+@AutoService(BesuPlugin.class)
+public class LineaExtraDataPlugin extends AbstractLineaRequiredPlugin {
+  public static final String NAME = "linea";
+  private BesuEvents besuEventsService;
+
+  @Override
+  public Optional<String> getName() {
+    return Optional.of(NAME);
+  }
+
+  @Override
+  public void doRegister(final BesuContext context) {
+    besuEventsService =
+        context
+            .getService(BesuEvents.class)
+            .orElseThrow(
+                () -> new RuntimeException("Failed to obtain BesuEvents from the BesuContext."));
+  }
+
+  @Override
+  public void beforeExternalServices() {
+    super.beforeExternalServices();
+    besuEventsService.addBlockAddedListener(new LineaExtraDataHandler());
+  }
+}

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
@@ -48,6 +48,6 @@ public class LineaExtraDataPlugin extends AbstractLineaRequiredPlugin {
   @Override
   public void beforeExternalServices() {
     super.beforeExternalServices();
-    besuEventsService.addBlockAddedListener(new LineaExtraDataHandler());
+    besuEventsService.addBlockAddedListener(new LineaExtraDataHandler(profitabilityConfiguration));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
@@ -23,6 +23,7 @@ import net.consensys.linea.AbstractLineaRequiredPlugin;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.services.BesuEvents;
+import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.RpcEndpointService;
 
 /** This plugin registers handlers that are activated when new blocks are imported */
@@ -32,6 +33,7 @@ public class LineaExtraDataPlugin extends AbstractLineaRequiredPlugin {
   public static final String NAME = "linea";
   private BesuEvents besuEventsService;
   private RpcEndpointService rpcEndpointService;
+  private BlockchainService blockchainService;
 
   @Override
   public Optional<String> getName() {
@@ -52,12 +54,20 @@ public class LineaExtraDataPlugin extends AbstractLineaRequiredPlugin {
                 () ->
                     new RuntimeException(
                         "Failed to obtain RpcEndpointService from the BesuContext."));
+    blockchainService =
+        context
+            .getService(BlockchainService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain BlockchainService from the BesuContext."));
   }
 
   @Override
   public void start() {
     super.start();
     besuEventsService.addBlockAddedListener(
-        new LineaExtraDataHandler(rpcEndpointService, profitabilityConfiguration));
+        new LineaExtraDataHandler(
+            rpcEndpointService, blockchainService, profitabilityConfiguration, rpcConfiguration));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
@@ -23,6 +23,7 @@ import net.consensys.linea.AbstractLineaRequiredPlugin;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.services.BesuEvents;
+import org.hyperledger.besu.plugin.services.RpcEndpointService;
 
 /** This plugin registers handlers that are activated when new blocks are imported */
 @Slf4j
@@ -30,6 +31,7 @@ import org.hyperledger.besu.plugin.services.BesuEvents;
 public class LineaExtraDataPlugin extends AbstractLineaRequiredPlugin {
   public static final String NAME = "linea";
   private BesuEvents besuEventsService;
+  private RpcEndpointService rpcEndpointService;
 
   @Override
   public Optional<String> getName() {
@@ -43,11 +45,19 @@ public class LineaExtraDataPlugin extends AbstractLineaRequiredPlugin {
             .getService(BesuEvents.class)
             .orElseThrow(
                 () -> new RuntimeException("Failed to obtain BesuEvents from the BesuContext."));
+    rpcEndpointService =
+        context
+            .getService(RpcEndpointService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain RpcEndpointService from the BesuContext."));
   }
 
   @Override
-  public void beforeExternalServices() {
-    super.beforeExternalServices();
-    besuEventsService.addBlockAddedListener(new LineaExtraDataHandler(profitabilityConfiguration));
+  public void start() {
+    super.start();
+    besuEventsService.addBlockAddedListener(
+        new LineaExtraDataHandler(rpcEndpointService, profitabilityConfiguration));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
@@ -188,7 +188,7 @@ public class LineaEstimateGas {
 
     final Wei profitablePriorityFee =
         txProfitabilityCalculator.profitablePriorityFeePerGas(
-            transaction, profitabilityConf.estimateGasMinMargin(), minGasPrice, estimatedGasUsed);
+            transaction, profitabilityConf.estimateGasMinMargin(), estimatedGasUsed);
 
     if (profitablePriorityFee.greaterOrEqualThan(priorityFeeLowerBound)) {
       return profitablePriorityFee;

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
@@ -188,7 +188,7 @@ public class LineaEstimateGas {
 
     final Wei profitablePriorityFee =
         txProfitabilityCalculator.profitablePriorityFeePerGas(
-            transaction, profitabilityConf.estimateGasMinMargin(), estimatedGasUsed);
+            transaction, profitabilityConf.estimateGasMinMargin(), estimatedGasUsed, minGasPrice);
 
     if (profitablePriorityFee.greaterOrEqualThan(priorityFeeLowerBound)) {
       return profitablePriorityFee;

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
@@ -43,6 +43,7 @@ import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.datatypes.rpc.RpcMethodError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
@@ -55,7 +56,6 @@ import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.TransactionSimulationService;
 import org.hyperledger.besu.plugin.services.exception.PluginRpcEndpointException;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
-import org.hyperledger.besu.plugin.services.rpc.RpcMethodError;
 
 @Slf4j
 public class LineaEstimateGas {

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidator.java
@@ -56,7 +56,8 @@ public class ProfitabilityValidator implements PluginTransactionPoolValidator {
               transaction,
               profitabilityConf.txPoolMinMargin(),
               calculateUpfrontGasPrice(transaction),
-              transaction.getGasLimit())
+              transaction.getGasLimit(),
+              besuConfiguration.getMinGasPrice())
           ? Optional.empty()
           : Optional.of("Gas price too low");
     }

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidator.java
@@ -55,7 +55,6 @@ public class ProfitabilityValidator implements PluginTransactionPoolValidator {
               "Txpool",
               transaction,
               profitabilityConf.txPoolMinMargin(),
-              besuConfiguration.getMinGasPrice(),
               calculateUpfrontGasPrice(transaction),
               transaction.getGasLimit())
           ? Optional.empty()

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelector.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelector.java
@@ -80,7 +80,6 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
           "PreProcessing",
           transaction,
           profitabilityConf.minMargin(),
-          minGasPrice,
           evaluationContext.getTransactionGasPrice(),
           gasLimit)) {
         return TX_UNPROFITABLE_UPFRONT;
@@ -133,7 +132,6 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
           "PostProcessing",
           transaction,
           profitabilityConf.minMargin(),
-          evaluationContext.getMinGasPrice(),
           evaluationContext.getTransactionGasPrice(),
           gasUsed)) {
         rememberUnprofitable(transaction);

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelector.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelector.java
@@ -81,7 +81,8 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
           transaction,
           profitabilityConf.minMargin(),
           evaluationContext.getTransactionGasPrice(),
-          gasLimit)) {
+          gasLimit,
+          minGasPrice)) {
         return TX_UNPROFITABLE_UPFRONT;
       }
 
@@ -133,7 +134,8 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
           transaction,
           profitabilityConf.minMargin(),
           evaluationContext.getTransactionGasPrice(),
-          gasUsed)) {
+          gasUsed,
+          evaluationContext.getMinGasPrice())) {
         rememberUnprofitable(transaction);
         return TX_UNPROFITABLE;
       }

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidatorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidatorTest.java
@@ -47,8 +47,8 @@ public class ProfitabilityValidatorTest {
       Address.fromHexString("0x0000000000000000000000000000000000001000");
   public static final Address RECIPIENT =
       Address.fromHexString("0x0000000000000000000000000000000000001001");
-  private static Wei PROFITABLE_GAS_PRICE = Wei.of(11000000);
-  private static Wei UNPROFITABLE_GAS_PRICE = Wei.of(1000000);
+  private static Wei PROFITABLE_GAS_PRICE = Wei.of(11_000_000);
+  private static Wei UNPROFITABLE_GAS_PRICE = Wei.of(200_000);
   private static final SECPSignature FAKE_SIGNATURE;
 
   static {

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
@@ -41,8 +41,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ProfitableTransactionSelectorTest {
-  private static final int FIXED_GAS_COST_KWEI = 0;
-  private static final int VARIABLE_GAS_COST_KWEI = 1_000_000;
+  private static final int FIXED_GAS_COST_WEI = 0;
+  private static final int VARIABLE_GAS_COST_WEI = 1_000_000_000;
   private static final double MIN_MARGIN = 1.0;
   private static final int UNPROFITABLE_CACHE_SIZE = 2;
   private static final int UNPROFITABLE_RETRY_LIMIT = 1;
@@ -54,8 +54,8 @@ public class ProfitableTransactionSelectorTest {
   private final LineaProfitabilityConfiguration profitabilityConf =
       LineaProfitabilityCliOptions.create().toDomainObject().toBuilder()
           .minMargin(MIN_MARGIN)
-          .fixedCostKWei(FIXED_GAS_COST_KWEI)
-          .variableCostKWei(VARIABLE_GAS_COST_KWEI)
+          .fixedCostWei(FIXED_GAS_COST_WEI)
+          .variableCostWei(VARIABLE_GAS_COST_WEI)
           .build();
   private TestableProfitableTransactionSelector transactionSelector;
 

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
@@ -41,8 +41,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ProfitableTransactionSelectorTest {
-  private static final int FIXED_GAS_COST_KWEI = 1_200_000;
-  private static final int VARIABLE_GAS_COST_KWEI = 90_000;
+  private static final int FIXED_GAS_COST_KWEI = 0;
+  private static final int VARIABLE_GAS_COST_KWEI = 1_000_000;
   private static final double MIN_MARGIN = 1.0;
   private static final int UNPROFITABLE_CACHE_SIZE = 2;
   private static final int UNPROFITABLE_RETRY_LIMIT = 1;

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
@@ -41,9 +41,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ProfitableTransactionSelectorTest {
-  private static final int VERIFICATION_GAS_COST = 1_200_000;
-  private static final int VERIFICATION_CAPACITY = 90_000;
-  private static final int GAS_PRICE_RATIO = 15;
+  private static final int FIXED_GAS_COST_KWEI = 1_200_000;
+  private static final int VARIABLE_GAS_COST_KWEI = 90_000;
   private static final double MIN_MARGIN = 1.0;
   private static final int UNPROFITABLE_CACHE_SIZE = 2;
   private static final int UNPROFITABLE_RETRY_LIMIT = 1;
@@ -54,10 +53,9 @@ public class ProfitableTransactionSelectorTest {
           .build();
   private final LineaProfitabilityConfiguration profitabilityConf =
       LineaProfitabilityCliOptions.create().toDomainObject().toBuilder()
-          .gasPriceRatio(GAS_PRICE_RATIO)
           .minMargin(MIN_MARGIN)
-          .verificationCapacity(VERIFICATION_CAPACITY)
-          .verificationGasCost(VERIFICATION_GAS_COST)
+          .fixedCostKWei(FIXED_GAS_COST_KWEI)
+          .variableCostKWei(VARIABLE_GAS_COST_KWEI)
           .build();
   private TestableProfitableTransactionSelector transactionSelector;
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/testing/ToyAccount.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/testing/ToyAccount.java
@@ -69,6 +69,11 @@ public class ToyAccount implements MutableAccount {
   }
 
   @Override
+  public boolean isStorageEmpty() {
+    return false;
+  }
+
+  @Override
   public Hash getAddressHash() {
     return addressHash.get();
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/testing/ToyExecutionEnvironment.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/testing/ToyExecutionEnvironment.java
@@ -165,7 +165,6 @@ public class ToyExecutionEnvironment {
       for (Transaction tx : body.getTransactions()) {
         final TransactionProcessingResult result =
             transactionProcessor.processTransaction(
-                null,
                 overridenToyWorld.updater(),
                 (ProcessableBlockHeader) header,
                 tx,
@@ -198,7 +197,6 @@ public class ToyExecutionEnvironment {
     for (Transaction tx : mockBlockBody.getTransactions()) {
       final TransactionProcessingResult result =
           transactionProcessor.processTransaction(
-              null,
               toyWorld.updater(),
               (ProcessableBlockHeader) header,
               tx,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=0.1.4-SNAPSHOT
-besuVersion=24.4-develop-a5a3eb8
+besuVersion=24.5-develop-0513bfa
 besuArtifactGroup=io.consensys.linea-besu
 distributionIdentifier=besu-sequencer-plugins
 distributionBaseUrl=https://artifacts.consensys.net/public/linea-besu/raw/names/linea-besu.tar.gz/versions/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=0.1.4-SNAPSHOT
-besuVersion=24.5-fdf
+besuVersion=24.5-develop-0cfa46b
 besuArtifactGroup=io.consensys.linea-besu
 distributionIdentifier=besu-sequencer-plugins
 distributionBaseUrl=https://artifacts.consensys.net/public/linea-besu/raw/names/linea-besu.tar.gz/versions/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=0.1.4-SNAPSHOT
-besuVersion=24.5-develop-0513bfa
+besuVersion=24.5-fdf
 besuArtifactGroup=io.consensys.linea-besu
 distributionIdentifier=besu-sequencer-plugins
 distributionBaseUrl=https://artifacts.consensys.net/public/linea-besu/raw/names/linea-besu.tar.gz/versions/

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -31,6 +31,7 @@ repositories {
     content { includeGroupByRegex('com\\.splunk\\..*') }
   }
   mavenCentral()
+  mavenLocal()
 }
 
 configurations.all {

--- a/gradle/dist.gradle
+++ b/gradle/dist.gradle
@@ -27,16 +27,37 @@ tasks.register('javadocJar', Jar) {
   from javadoc.destinationDir
 }
 
+def lineaBesuDistTar = new File(buildDir, rootProject.besuFilename)
+
+tasks.register('copyLocalLineaBesu', Copy) {
+  onlyIf {
+    project.hasProperty('useLocalLineaBesuDir')
+  }
+  def localLineaBesuDir = "${findProperty('useLocalLineaBesuDir')}".replaceFirst('^~', System.getProperty('user.home'))
+  doFirst {
+    if (!file(localLineaBesuDir).exists()) {
+      throw new GradleException("${localLineaBesuDir} not found")
+    }
+  }
+
+  from new File("${localLineaBesuDir}/build/distributions/${rootProject.besuFilename}")
+  into lineaBesuDistTar.parentFile
+}
+
 tasks.register('downloadLatestLineaBesu', Download) {
-  src rootProject.besuUrl
-  dest new File(buildDir, rootProject.besuFilename)
-  onlyIfModified true
+  onlyIf {
+    !project.hasProperty('useLocalLineaBesuDir')
+  }
+    src rootProject.besuUrl
+    dest lineaBesuDistTar
+    onlyIfModified true
 }
 
 version = project.hasProperty('releaseVersion') ? project.getProperty('releaseVersion') : 'snapshot'
 
 jar {
   dependsOn downloadLatestLineaBesu
+  dependsOn copyLocalLineaBesu
 
   archiveBaseName = distributionIdentifier
 
@@ -76,8 +97,9 @@ static def getCheckedOutGitCommitHash() {
 tasks.register('distTar', Tar) {
   dependsOn jar
   dependsOn downloadLatestLineaBesu
+  dependsOn copyLocalLineaBesu
 
-  from(tarTree(downloadLatestLineaBesu.dest), {
+  from(tarTree(lineaBesuDistTar), {
     eachFile { path = path.replaceFirst(rootProject.besuIdentifier, '') }
     includeEmptyDirs = false
     exclude "**/LICENSE"

--- a/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
+++ b/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
@@ -126,7 +126,6 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
       zkTracer.traceStartBlock(blockHeader, blockBody);
       final TransactionProcessingResult result =
           transactionProcessor.processTransaction(
-              blockchain,
               worldStateUpdater,
               blockHeader,
               transaction,

--- a/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
+++ b/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
@@ -31,7 +31,6 @@ import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.ethereum.core.Deposit;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
@@ -48,8 +47,8 @@ import org.hyperledger.besu.ethereum.privacy.storage.PrivateMetadataUpdater;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldState;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldStateUpdateAccumulator;
-import org.hyperledger.besu.ethereum.vm.BlockHashLookup;
 import org.hyperledger.besu.ethereum.vm.CachingBlockHashLookup;
+import org.hyperledger.besu.evm.operation.BlockHashOperation;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 @Slf4j
@@ -84,7 +83,6 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
       final List<Transaction> transactions,
       final List<BlockHeader> ommers,
       final Optional<List<Withdrawal>> maybeWithdrawals,
-      final Optional<List<Deposit>> maybeDeposits,
       final PrivateMetadataUpdater privateMetadataUpdater) {
     final List<TransactionReceipt> receipts = new ArrayList<>();
     long currentGasUsed = 0;
@@ -105,7 +103,8 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
 
       final WorldUpdater worldStateUpdater = worldState.updater();
 
-      final BlockHashLookup blockHashLookup = new CachingBlockHashLookup(blockHeader, blockchain);
+      final BlockHashOperation.BlockHashLookup blockHashLookup =
+          new CachingBlockHashLookup(blockHeader, blockchain);
       final Address miningBeneficiary =
           miningBeneficiaryCalculator.calculateBeneficiary(blockHeader);
 

--- a/reference-tests/src/test/java/net/consensys/linea/GeneralStateReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/GeneralStateReferenceTestTools.java
@@ -175,7 +175,6 @@ public class GeneralStateReferenceTestTools {
 
     final TransactionProcessingResult result =
         processor.processTransaction(
-            blockchain,
             worldStateUpdater,
             blockHeader,
             transaction,


### PR DESCRIPTION
Update the transaction profitability formula as specified in https://github.com/Consensys/protocol-misc/issues/899

Extract the values of the `fixedGasCostKWei`, `variableGasCostKWei` and `minGasPriceKWei` from the extra data field in the block header of imported blocks, converts them to wei and updated the profitability runtime parameters and update the minGasPrice, when the `plugin-linea-extra-data-pricing-enabled` flag is set to true.

On startup try to extract the values from the extra data field of the current chain head, otherwise used the values passed via CLI or config file, as fallback their defaults.

Add the following CLI options
- `plugin-linea-fixed-gas-cost-wei` by default 0 wei
- `plugin-linea-variable-gas-cost-wei` by default 1000000000 = 1Gwei
- `plugin-linea-extra-data-pricing-enabled` set to true to enable pricing based on extra data field content (by default: false)

Remove the now unused CLI options:
1. `plugin-linea-verification-gas-cost`
2. `plugin-linea-verification-capacity`
3. `plugin-linea-gas-price-ratio`
4. `plugin-linea-gas-price-adjustment`
