### PR TITLE
Remove check that minGasPrice need to decrease to retry unprofitable tx

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectionResult.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectionResult.java
@@ -26,8 +26,7 @@ public class LineaTransactionSelectionResult extends TransactionSelectionResult 
     TX_MODULE_LINE_COUNT_OVERFLOW_CACHED(false, true),
     TX_UNPROFITABLE(false, false),
     TX_UNPROFITABLE_UPFRONT(false, false),
-    TX_UNPROFITABLE_RETRY_LIMIT(false, false),
-    TX_UNPROFITABLE_MIN_GAS_PRICE_NOT_DECREASED(false, false);
+    TX_UNPROFITABLE_RETRY_LIMIT(false, false);
 
     private final boolean stop;
     private final boolean discard;
@@ -70,6 +69,4 @@ public class LineaTransactionSelectionResult extends TransactionSelectionResult 
       new LineaTransactionSelectionResult(LineaStatus.TX_UNPROFITABLE_UPFRONT);
   public static final TransactionSelectionResult TX_UNPROFITABLE_RETRY_LIMIT =
       new LineaTransactionSelectionResult(LineaStatus.TX_UNPROFITABLE_RETRY_LIMIT);
-  public static final TransactionSelectionResult TX_UNPROFITABLE_MIN_GAS_PRICE_NOT_DECREASED =
-      new LineaTransactionSelectionResult(LineaStatus.TX_UNPROFITABLE_MIN_GAS_PRICE_NOT_DECREASED);
 }


### PR DESCRIPTION
The check that minGasPrice need to decrease to retry unprofitable tx, is a small optimization to avoid some profitability checks, not sure it has a big impact, and not that the profitability formula is changed, it should be adapted, but I prefer to remove it altogether instead, since probably not worth the added complexity, and we can always re-evaluate it in case we discover some performance issue there.