### PR TITLE
Align linea_estimateGas behavior to geth

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -93,7 +93,8 @@ The validators are in the package `net.consensys.linea.sequencer.txpoolvalidatio
 ### Linea Estimate Gas
 #### `linea_estimateGas`
 
-This endpoint simulates a transaction, including line count limit validation, and returns the estimated gas used ( as the standard `eth_estimateGas`) plus the estimated gas price to be used when submitting the tx. 
+This endpoint simulates a transaction, including line count limit validation, and returns the estimated gas used 
+(as the standard `eth_estimateGas` with `strict=true`) plus the estimated gas price to be used when submitting the tx. 
 
 #### Parameters
 same as `eth_estimateGas`


### PR DESCRIPTION
Set `isAllowExceedingBalance` to false when simulating the tx, makes the estimation taking in account also the gas price/gas fee passed as input, and result in better gas estimations, and it is aligned with what geth returns by default.
Also defaulting the `gasPrice` field to the baseFee, when not present in the request, only if not trying to simulate a base fee market tx