### PR TITLE
Re-add dependencies to the jar and change duplication strategy

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ releaseVersion=0.1.5-SNAPSHOT
 besuVersion=24.6-develop-752aeff
 arithmetizationVersion=0.1.5-rc1
 besuArtifactGroup=io.consensys.linea-besu
-distributionIdentifier=linea-sequencer-plugins
+distributionIdentifier=linea-sequencer
 distributionBaseUrl=https://artifacts.consensys.net/public/linea-besu/raw/names/linea-besu.tar.gz/versions/
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ releaseVersion=0.1.5-SNAPSHOT
 besuVersion=24.6-develop-752aeff
 arithmetizationVersion=0.1.5-rc1
 besuArtifactGroup=io.consensys.linea-besu
-distributionIdentifier=besu-sequencer-plugins
+distributionIdentifier=linea-sequencer-plugins
 distributionBaseUrl=https://artifacts.consensys.net/public/linea-besu/raw/names/linea-besu.tar.gz/versions/
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.

--- a/gradle/dist.gradle
+++ b/gradle/dist.gradle
@@ -70,12 +70,12 @@ jar {
     )
   }
 
-/*  from {
+ from {
     configurations.runtimeClasspath.filter( {! (it.name =~ /log4j.*\.jar/ )} )
             .collect {it.isDirectory() ? it : zipTree(it) }
   }
   exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
-  duplicatesStrategy(DuplicatesStrategy.INCLUDE)*/
+  duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 }
 
 // Takes the version, and if -SNAPSHOT is part of it replaces SNAPSHOT

--- a/sequencer/build.gradle
+++ b/sequencer/build.gradle
@@ -38,16 +38,16 @@ dependencies {
   compileOnly 'com.google.auto.service:auto-service'
   compileOnly 'com.google.auto.service:auto-service-annotations'
 
-  implementation "${besuArtifactGroup}:evm"
-  implementation "${besuArtifactGroup}:plugin-api"
-  implementation "${besuArtifactGroup}:besu-datatypes"
-  implementation "${besuArtifactGroup}.internal:api:${besuVersion}"
-  implementation "${besuArtifactGroup}.internal:core:${besuVersion}"
-  implementation "${besuArtifactGroup}.internal:rlp:${besuVersion}"
-  implementation "${besuArtifactGroup}.internal:algorithms:${besuVersion}"
+  compileOnly "${besuArtifactGroup}:evm"
+  compileOnly "${besuArtifactGroup}:plugin-api"
+  compileOnly "${besuArtifactGroup}:besu-datatypes"
+  compileOnly "${besuArtifactGroup}.internal:api:${besuVersion}"
+  compileOnly "${besuArtifactGroup}.internal:core:${besuVersion}"
+  compileOnly "${besuArtifactGroup}.internal:rlp:${besuVersion}"
+  compileOnly "${besuArtifactGroup}.internal:algorithms:${besuVersion}"
   implementation project(":native:compress")
 
-  implementation 'info.picocli:picocli'
+  compileOnly 'info.picocli:picocli'
 
   compileOnly 'io.vertx:vertx-core'
 


### PR DESCRIPTION
- Re-add dependencies to the jar
- Change the duplication strategy to exclude instead of include so that `META-INF/services` will contain that right `org.hyperledger.besu.plugin.BesuPlugin` file
- Rename distributionIdentifier to `linea-sequencer` instead of `besu-sequencer-plugins`