### PR TITLE
Include baseFee in the calculation of a profitable tx

### DIFF
--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -161,6 +161,7 @@ public class EstimateGasTest extends LineaPluginTestBase {
                 "Test",
                 tx,
                 profitabilityConf.estimateGasMinMargin(),
+                baseFee,
                 estimatedMaxGasPrice,
                 estimatedGasLimit,
                 minGasPrice))

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactory.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactory.java
@@ -22,11 +22,13 @@ import net.consensys.linea.config.LineaProfitabilityConfiguration;
 import net.consensys.linea.config.LineaTracerConfiguration;
 import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import net.consensys.linea.sequencer.txselection.selectors.LineaTransactionSelector;
+import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelectorFactory;
 
 /** Represents a factory for creating transaction selectors. */
 public class LineaTransactionSelectorFactory implements PluginTransactionSelectorFactory {
+  private final BlockchainService blockchainService;
   private final LineaTransactionSelectorConfiguration txSelectorConfiguration;
   private final LineaL1L2BridgeConfiguration l1L2BridgeConfiguration;
   private final LineaProfitabilityConfiguration profitabilityConfiguration;
@@ -35,11 +37,13 @@ public class LineaTransactionSelectorFactory implements PluginTransactionSelecto
   private final Map<String, Integer> limitsMap;
 
   public LineaTransactionSelectorFactory(
+      final BlockchainService blockchainService,
       final LineaTransactionSelectorConfiguration txSelectorConfiguration,
       final LineaL1L2BridgeConfiguration l1L2BridgeConfiguration,
       final LineaProfitabilityConfiguration profitabilityConfiguration,
       final LineaTracerConfiguration tracerConfiguration,
       final Map<String, Integer> limitsMap) {
+    this.blockchainService = blockchainService;
     this.txSelectorConfiguration = txSelectorConfiguration;
     this.l1L2BridgeConfiguration = l1L2BridgeConfiguration;
     this.profitabilityConfiguration = profitabilityConfiguration;
@@ -50,6 +54,7 @@ public class LineaTransactionSelectorFactory implements PluginTransactionSelecto
   @Override
   public PluginTransactionSelector create() {
     return new LineaTransactionSelector(
+        blockchainService,
         txSelectorConfiguration,
         l1L2BridgeConfiguration,
         profitabilityConfiguration,

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.AbstractLineaRequiredPlugin;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.TransactionSelectionService;
 
 /**
@@ -36,6 +37,7 @@ import org.hyperledger.besu.plugin.services.TransactionSelectionService;
 public class LineaTransactionSelectorPlugin extends AbstractLineaRequiredPlugin {
   public static final String NAME = "linea";
   private TransactionSelectionService transactionSelectionService;
+  private BlockchainService blockchainService;
 
   @Override
   public Optional<String> getName() {
@@ -51,6 +53,14 @@ public class LineaTransactionSelectorPlugin extends AbstractLineaRequiredPlugin 
                 () ->
                     new RuntimeException(
                         "Failed to obtain TransactionSelectionService from the BesuContext."));
+
+    blockchainService =
+        context
+            .getService(BlockchainService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain BlockchainService from the BesuContext."));
   }
 
   @Override
@@ -58,6 +68,7 @@ public class LineaTransactionSelectorPlugin extends AbstractLineaRequiredPlugin 
     super.beforeExternalServices();
     transactionSelectionService.registerPluginTransactionSelectorFactory(
         new LineaTransactionSelectorFactory(
+            blockchainService,
             transactionSelectorConfiguration,
             l1L2BridgeConfiguration,
             profitabilityConfiguration,

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -25,6 +25,7 @@ import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
+import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;
 import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
@@ -37,6 +38,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
   private final List<PluginTransactionSelector> selectors;
 
   public LineaTransactionSelector(
+      final BlockchainService blockchainService,
       final LineaTransactionSelectorConfiguration txSelectorConfiguration,
       final LineaL1L2BridgeConfiguration l1L2BridgeConfiguration,
       final LineaProfitabilityConfiguration profitabilityConfiguration,
@@ -44,6 +46,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
       final Map<String, Integer> limitsMap) {
     this.selectors =
         createTransactionSelectors(
+            blockchainService,
             txSelectorConfiguration,
             l1L2BridgeConfiguration,
             profitabilityConfiguration,
@@ -54,12 +57,14 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
   /**
    * Creates a list of selectors based on Linea configuration.
    *
+   * @param blockchainService
    * @param txSelectorConfiguration The configuration to use.
    * @param profitabilityConfiguration
    * @param limitsMap The limits map.
    * @return A list of selectors.
    */
   private List<PluginTransactionSelector> createTransactionSelectors(
+      final BlockchainService blockchainService,
       final LineaTransactionSelectorConfiguration txSelectorConfiguration,
       final LineaL1L2BridgeConfiguration l1L2BridgeConfiguration,
       final LineaProfitabilityConfiguration profitabilityConfiguration,
@@ -73,7 +78,8 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
     return List.of(
         new MaxBlockCallDataTransactionSelector(txSelectorConfiguration.maxBlockCallDataSize()),
         new MaxBlockGasTransactionSelector(txSelectorConfiguration.maxGasPerBlock()),
-        new ProfitableTransactionSelector(txSelectorConfiguration, profitabilityConfiguration),
+        new ProfitableTransactionSelector(
+            blockchainService, txSelectorConfiguration, profitabilityConfiguration),
         traceLineLimitTransactionSelector);
   }
 


### PR DESCRIPTION
While working on documentation, I found that the baseFee was not added to the profitable priorityFeePerGas when calculating if the gas price that the tx is willing to pay is profitable, this PR fixes that.

Note: at the moment since the baseFee on Linea is constant at 7 Wei, basically there is no difference, but this could change in future.