### PR TITLE
CHANGELOG for Release v0.1.5-test1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.5-test1
+First release of the new series that uses on the ZkTracer as dependency from `linea-arithmetization` repo
+* arithmetizationVersion=0.1.5-rc3 [#29](https://github.com/Consensys/linea-sequencer/pull/29)
+* Align linea_estimateGas behavior to geth [#25](https://github.com/Consensys/linea-sequencer/pull/25)
+* Implement linea_setExtraData [#19](https://github.com/Consensys/linea-sequencer/pull/19)
+* Set plugin-linea-tx-pool-simulation-check-api-enabled=false by default [#23](https://github.com/Consensys/linea-sequencer/pull/23)
+
 ## 0.1.4-test28
 Test pre-release 28 from [temp/issue-248/count-stack-only](https://github.com/Consensys/besu-sequencer-plugins/tree/temp/issue-248/count-stack-only)
 * Extra data based pricing [#10](https://github.com/Consensys/linea-sequencer/pull/10)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion=0.1.5-SNAPSHOT
+releaseVersion=0.1.5-test1
 besuVersion=24.6-develop-752aeff
 arithmetizationVersion=0.1.5-rc3
 besuArtifactGroup=io.consensys.linea-besu


### PR DESCRIPTION
## 0.1.5-test1
First release of the new series that uses on the ZkTracer as dependency from `linea-arithmetization` repo
* arithmetizationVersion=0.1.5-rc3 [#29](https://github.com/Consensys/linea-sequencer/pull/29)
* Align linea_estimateGas behavior to geth [#25](https://github.com/Consensys/linea-sequencer/pull/25)
* Implement linea_setExtraData [#19](https://github.com/Consensys/linea-sequencer/pull/19)
* Set plugin-linea-tx-pool-simulation-check-api-enabled=false by default [#23](https://github.com/Consensys/linea-sequencer/pull/23)
