### PR TITLE
Remove the check that profitable priority fee must be greater than minGasPrice

### DIFF
--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasCompatibilityModeTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasCompatibilityModeTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
+import org.junit.jupiter.api.Test;
 
 public class EstimateGasCompatibilityModeTest extends EstimateGasTest {
   private static final BigDecimal PRICE_MULTIPLIER = BigDecimal.valueOf(1.2);
@@ -62,5 +64,21 @@ public class EstimateGasCompatibilityModeTest extends EstimateGasTest {
     // since we are in compatibility mode, we want to check that returned profitable priority fee is
     // the min priority fee per gas * multiplier + base fee
     assertIsProfitable(null, baseFee, estimatedMaxGasPrice, 0);
+  }
+
+  @Test
+  public void lineaEstimateGasPriorityFeeMinGasPriceLowerBound() {
+    final Account sender = accounts.getSecondaryBenefactor();
+
+    final CallParams callParams = new CallParams(sender.getAddress(), null, "", "", "0");
+
+    final var reqLinea = new LineaEstimateGasRequest(callParams);
+    final var respLinea = reqLinea.execute(minerNode.nodeRequests());
+
+    final var baseFee = Wei.fromHexString(respLinea.baseFeePerGas());
+    final var estimatedPriorityFee = Wei.fromHexString(respLinea.priorityFeePerGas());
+    final var estimatedMaxGasPrice = baseFee.add(estimatedPriorityFee);
+
+    assertMinGasPriceLowerBound(baseFee, estimatedMaxGasPrice);
   }
 }

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -51,7 +51,7 @@ public class EstimateGasTest extends LineaPluginTestBase {
   protected static final int FIXED_GAS_COST_WEI = 0;
   protected static final int VARIABLE_GAS_COST_WEI = 1_000_000_000;
   protected static final double MIN_MARGIN = 1.0;
-  protected static final double ESTIMATE_GAS_MIN_MARGIN = 1.0;
+  protected static final double ESTIMATE_GAS_MIN_MARGIN = 1.1;
   protected static final Wei MIN_GAS_PRICE = Wei.of(1_000_000_000);
   protected static final int MAX_TRANSACTION_GAS_LIMIT = 30_000_000;
   protected LineaProfitabilityConfiguration profitabilityConf;
@@ -154,34 +154,16 @@ public class EstimateGasTest extends LineaPluginTestBase {
 
     final var profitabilityCalculator = new TransactionProfitabilityCalculator(profitabilityConf);
 
-    assertThat(estimatedMaxGasPrice.greaterOrEqualThan(minGasPrice)).isTrue();
-
     assertThat(
             profitabilityCalculator.isProfitable(
                 "Test",
                 tx,
-                profitabilityConf.estimateGasMinMargin(),
+                profitabilityConf.minMargin(),
                 baseFee,
                 estimatedMaxGasPrice,
                 estimatedGasLimit,
                 minGasPrice))
         .isTrue();
-  }
-
-  @Test
-  public void lineaEstimateGasPriorityFeeMinGasPriceLowerBound() {
-    final Account sender = accounts.getSecondaryBenefactor();
-
-    final CallParams callParams = new CallParams(sender.getAddress(), null, "", "", "0");
-
-    final var reqLinea = new LineaEstimateGasRequest(callParams);
-    final var respLinea = reqLinea.execute(minerNode.nodeRequests());
-
-    final var baseFee = Wei.fromHexString(respLinea.baseFeePerGas());
-    final var estimatedPriorityFee = Wei.fromHexString(respLinea.priorityFeePerGas());
-    final var estimatedMaxGasPrice = baseFee.add(estimatedPriorityFee);
-
-    assertMinGasPriceLowerBound(baseFee, estimatedMaxGasPrice);
   }
 
   @Test

--- a/sequencer/src/main/java/net/consensys/linea/rpc/LineaEstimateGas.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/LineaEstimateGas.java
@@ -189,18 +189,7 @@ public class LineaEstimateGas {
         txProfitabilityCalculator.profitablePriorityFeePerGas(
             transaction, profitabilityConf.estimateGasMinMargin(), estimatedGasUsed, minGasPrice);
 
-    if (profitablePriorityFee.greaterOrEqualThan(priorityFeeLowerBound)) {
-      return profitablePriorityFee;
-    }
-
-    log.atDebug()
-        .setMessage(
-            "[{}] Estimated priority fee {} is lower that the lower bound {}, returning the latter")
-        .addArgument(LOG_SEQUENCE::get)
-        .addArgument(profitablePriorityFee::toHumanReadableString)
-        .addArgument(priorityFeeLowerBound::toHumanReadableString)
-        .log();
-    return priorityFeeLowerBound;
+    return profitablePriorityFee;
   }
 
   private Long estimateGasUsed(


### PR DESCRIPTION
Remove the check that profitable priority fee must be greater than minGasPrice, as per chat below

Roman Vaseev
  1 hour ago
Estimated priority fee 11.93 mwei is lower that the lower bound 272.73 mwei, returning the latter


Fabio Di Fabio
  [1 hour ago](https://consensys.slack.com/archives/C06N13XERJP/p1721645892046249?thread_ts=1721642020.976209&cid=C06N13XERJP)
ok the lower bound check was triggered, is it correct to have it?


Fabio Di Fabio
  1 hour ago
I remember I added it to avoid returning something that is below the minGasPrice


Roman Vaseev
  [1 hour ago](https://consensys.slack.com/archives/C06N13XERJP/p1721646053866449?thread_ts=1721642020.976209&cid=C06N13XERJP)
It's only correct for compatibility mode