### PR TITLE
Fix `linea_estimateGas` when called with `gasPrice` set

### DIFF
--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasCompatibilityModeTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasCompatibilityModeTest.java
@@ -70,10 +70,10 @@ public class EstimateGasCompatibilityModeTest extends EstimateGasTest {
   public void lineaEstimateGasPriorityFeeMinGasPriceLowerBound() {
     final Account sender = accounts.getSecondaryBenefactor();
 
-    final CallParams callParams = new CallParams(sender.getAddress(), null, "", "", "0");
+    final CallParams callParams = new CallParams(sender.getAddress(), null, "", "", "0", null);
 
     final var reqLinea = new LineaEstimateGasRequest(callParams);
-    final var respLinea = reqLinea.execute(minerNode.nodeRequests());
+    final var respLinea = reqLinea.execute(minerNode.nodeRequests()).getResult();
 
     final var baseFee = Wei.fromHexString(respLinea.baseFeePerGas());
     final var estimatedPriorityFee = Wei.fromHexString(respLinea.priorityFeePerGas());

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasModuleLimitOverflowTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasModuleLimitOverflowTest.java
@@ -52,7 +52,8 @@ public class EstimateGasModuleLimitOverflowTest extends LineaPluginTestBase {
             simpleStorage.getContractAddress(),
             null,
             payload.toHexString(),
-            "0");
+            "0",
+            null);
 
     final var reqLinea = new EstimateGasTest.BadLineaEstimateGasRequest(callParams);
     final var respLinea = reqLinea.execute(minerNode.nodeRequests());


### PR DESCRIPTION
Fix for this incorrect response, since baseFee is 7 wei

```
curl https://rpc.sepolia.linea.build/ \
       -X POST \
       -H "Content-Type: application/json" \
       -d '{"jsonrpc": "2.0","method": "linea_estimateGas","params": [{"from": "0x432C961E222FC3522FD31af85E84C6240fF0b46F","gasPrice":"0x110000000007","gas":"0x21000"}],"id": 53}'
{"jsonrpc":"2.0","id":53,"error":{"code":-32000,"message":"gasPrice is less than the current BaseFee"}}%
```