### PR TITLE
Fix: postpone registration of plugin validator factory when blockchain service is fully initialized

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
@@ -92,8 +92,8 @@ public class LineaTransactionPoolValidatorPlugin extends AbstractLineaRequiredPl
   }
 
   @Override
-  public void beforeExternalServices() {
-    super.beforeExternalServices();
+  public void start() {
+    super.start();
     try (Stream<String> lines =
         Files.lines(
             Path.of(new File(transactionPoolValidatorConfiguration().denyListPath()).toURI()))) {


### PR DESCRIPTION
`BlockchainService` is only fully initialized when the `start` method of a plugin is called, so postpone `transactionPoolValidatorService.registerPluginTransactionValidatorFactory` in the `start` method, this fix an issue that is present when restoring a saved txpool during the early startup process