### PR TITLE
[Refactoring] Split LineaEndpointServicePlugin methods into two classes

### DIFF
--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -31,7 +31,7 @@ import linea.plugin.acc.test.tests.web3j.generated.SimpleStorage;
 import net.consensys.linea.bl.TransactionProfitabilityCalculator;
 import net.consensys.linea.config.LineaProfitabilityCliOptions;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
-import net.consensys.linea.rpc.LineaEstimateGas;
+import net.consensys.linea.rpc.methods.LineaEstimateGas;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.bouncycastle.crypto.digests.KeccakDigest;

--- a/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaEstimateGas.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaEstimateGas.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.rpc;
+package net.consensys.linea.rpc.methods;
 
 import static net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator.ModuleLineCountResult.MODULE_NOT_DEFINED;
 import static net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator.ModuleLineCountResult.TX_MODULE_LINE_COUNT_OVERFLOW;

--- a/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSetExtraData.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSetExtraData.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.rpc;
+package net.consensys.linea.rpc.methods;
 
 import static net.consensys.linea.extradata.LineaExtraDataException.ErrorType.FAILED_CALLING_SET_EXTRA_DATA;
 import static net.consensys.linea.extradata.LineaExtraDataException.ErrorType.INVALID_ARGUMENT;

--- a/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaEstimateGasEndpointPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaEstimateGasEndpointPlugin.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.rpc.services;
+
+import static net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator.createLimitModules;
+
+import com.google.auto.service.AutoService;
+import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.AbstractLineaRequiredPlugin;
+import net.consensys.linea.rpc.methods.LineaEstimateGas;
+import org.hyperledger.besu.plugin.BesuContext;
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.services.BesuConfiguration;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+import org.hyperledger.besu.plugin.services.RpcEndpointService;
+import org.hyperledger.besu.plugin.services.TransactionSimulationService;
+
+/** Registers RPC endpoints. This class provides RPC endpoints under the 'linea' namespace. */
+@AutoService(BesuPlugin.class)
+@Slf4j
+public class LineaEstimateGasEndpointPlugin extends AbstractLineaRequiredPlugin {
+  private BesuConfiguration besuConfiguration;
+  private RpcEndpointService rpcEndpointService;
+  private TransactionSimulationService transactionSimulationService;
+  private BlockchainService blockchainService;
+  private LineaEstimateGas lineaEstimateGasMethod;
+
+  /**
+   * Register the RPC service.
+   *
+   * @param context the BesuContext to be used.
+   */
+  @Override
+  public void doRegister(final BesuContext context) {
+    besuConfiguration =
+        context
+            .getService(BesuConfiguration.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain BesuConfiguration from the BesuContext."));
+
+    rpcEndpointService =
+        context
+            .getService(RpcEndpointService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain RpcEndpointService from the BesuContext."));
+
+    transactionSimulationService =
+        context
+            .getService(TransactionSimulationService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain TransactionSimulatorService from the BesuContext."));
+
+    blockchainService =
+        context
+            .getService(BlockchainService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain BlockchainService from the BesuContext."));
+
+    lineaEstimateGasMethod =
+        new LineaEstimateGas(besuConfiguration, transactionSimulationService, blockchainService);
+
+    rpcEndpointService.registerRPCEndpoint(
+        lineaEstimateGasMethod.getNamespace(),
+        lineaEstimateGasMethod.getName(),
+        lineaEstimateGasMethod::execute);
+  }
+
+  @Override
+  public void beforeExternalServices() {
+    super.beforeExternalServices();
+    lineaEstimateGasMethod.init(
+        rpcConfiguration(),
+        transactionPoolValidatorConfiguration(),
+        profitabilityConfiguration(),
+        createLimitModules(tracerConfiguration()),
+        l1L2BridgeSharedConfiguration());
+  }
+}

--- a/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaSetExtraDataEndpointPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaSetExtraDataEndpointPlugin.java
@@ -13,30 +13,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.rpc;
-
-import static net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator.createLimitModules;
+package net.consensys.linea.rpc.services;
 
 import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.AbstractLineaRequiredPlugin;
 import net.consensys.linea.extradata.LineaExtraDataHandler;
+import net.consensys.linea.rpc.methods.LineaSetExtraData;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.services.BesuConfiguration;
-import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.RpcEndpointService;
-import org.hyperledger.besu.plugin.services.TransactionSimulationService;
 
 /** Registers RPC endpoints. This class provides RPC endpoints under the 'linea' namespace. */
 @AutoService(BesuPlugin.class)
 @Slf4j
-public class LineaEndpointServicePlugin extends AbstractLineaRequiredPlugin {
-  private BesuConfiguration besuConfiguration;
+public class LineaSetExtraDataEndpointPlugin extends AbstractLineaRequiredPlugin {
   private RpcEndpointService rpcEndpointService;
-  private TransactionSimulationService transactionSimulationService;
-  private BlockchainService blockchainService;
-  private LineaEstimateGas lineaEstimateGasMethod;
   private LineaSetExtraData lineaSetExtraDataMethod;
 
   /**
@@ -46,13 +38,6 @@ public class LineaEndpointServicePlugin extends AbstractLineaRequiredPlugin {
    */
   @Override
   public void doRegister(final BesuContext context) {
-    besuConfiguration =
-        context
-            .getService(BesuConfiguration.class)
-            .orElseThrow(
-                () ->
-                    new RuntimeException(
-                        "Failed to obtain BesuConfiguration from the BesuContext."));
 
     rpcEndpointService =
         context
@@ -61,30 +46,6 @@ public class LineaEndpointServicePlugin extends AbstractLineaRequiredPlugin {
                 () ->
                     new RuntimeException(
                         "Failed to obtain RpcEndpointService from the BesuContext."));
-
-    transactionSimulationService =
-        context
-            .getService(TransactionSimulationService.class)
-            .orElseThrow(
-                () ->
-                    new RuntimeException(
-                        "Failed to obtain TransactionSimulatorService from the BesuContext."));
-
-    blockchainService =
-        context
-            .getService(BlockchainService.class)
-            .orElseThrow(
-                () ->
-                    new RuntimeException(
-                        "Failed to obtain BlockchainService from the BesuContext."));
-
-    lineaEstimateGasMethod =
-        new LineaEstimateGas(besuConfiguration, transactionSimulationService, blockchainService);
-
-    rpcEndpointService.registerRPCEndpoint(
-        lineaEstimateGasMethod.getNamespace(),
-        lineaEstimateGasMethod.getName(),
-        lineaEstimateGasMethod::execute);
 
     lineaSetExtraDataMethod = new LineaSetExtraData(rpcEndpointService);
 
@@ -97,12 +58,6 @@ public class LineaEndpointServicePlugin extends AbstractLineaRequiredPlugin {
   @Override
   public void beforeExternalServices() {
     super.beforeExternalServices();
-    lineaEstimateGasMethod.init(
-        rpcConfiguration(),
-        transactionPoolValidatorConfiguration(),
-        profitabilityConfiguration(),
-        createLimitModules(tracerConfiguration()),
-        l1L2BridgeSharedConfiguration());
     lineaSetExtraDataMethod.init(
         new LineaExtraDataHandler(rpcEndpointService, profitabilityConfiguration()));
   }


### PR DESCRIPTION
## Description

This pull request splits the `LineaEndpointServicePlugin` into two separate plugins: `LineaEstimateGasEndpointPlugin` and `LineaSetExtraDataEndpointPlugin`. This change allows for more flexibility, as some nodes may not require both plugins to be registered simultaneously.

```diff
  # Plugin Registration Summary: 
  # Registered Plugins: 
  #  - LineaExtraDataPlugin (linea-sequencer/0.4.0-dev-e534f359)                                     
- #  - LineaEndpointServicePlugin (linea-sequencer/0.4.0-dev-e534f359)
+ #  - LineaEstimateGasEndpointPlugin (linea-sequencer/0.4.0-dev-e534f359)
+ #  - LineaSetExtraDataEndpointPlugin (linea-sequencer/0.4.0-dev-e534f359)
  #  - LineaTransactionPoolValidatorPlugin (linea-sequencer/0.4.0-dev-e534f359) 
  #  - LineaTransactionSelectorPlugin (linea-sequencer/0.4.0-dev-e534f359)
```