### PR TITLE
Log the transaction hash in the module limit warning

### DIFF
--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EthSendRawTransactionSimulationCheckTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EthSendRawTransactionSimulationCheckTest.java
@@ -78,7 +78,8 @@ public class EthSendRawTransactionSimulationCheckTest extends LineaPluginTestBas
 
     assertThat(signedTxContractInteractionResp.hasError()).isTrue();
     assertThat(signedTxContractInteractionResp.getError().getMessage())
-        .isEqualTo("Transaction line count for module ADD=2017 is above the limit 70");
+        .isEqualTo(
+            "Transaction 0xe813560d9a3aedff46be12fc32706d8fe9b6565dd7e2db47457a9c416f2d45d7 line count for module ADD=2017 is above the limit 70");
 
     assertThat(getTxPoolContent()).isEmpty();
 

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
@@ -91,7 +91,7 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
           transaction, isLocal, hasPriority, maybeSimulationResults, moduleLimitResult);
 
       if (moduleLimitResult.getResult() != ModuleLineCountValidator.ModuleLineCountResult.VALID) {
-        return Optional.of(handleModuleOverLimit(moduleLimitResult));
+        return Optional.of(handleModuleOverLimit(transaction, moduleLimitResult));
       }
 
       if (maybeSimulationResults.isPresent()) {
@@ -150,7 +150,8 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
     return zkTracer;
   }
 
-  private String handleModuleOverLimit(ModuleLimitsValidationResult moduleLimitResult) {
+  private String handleModuleOverLimit(
+      Transaction transaction, ModuleLimitsValidationResult moduleLimitResult) {
     if (moduleLimitResult.getResult() == MODULE_NOT_DEFINED) {
       String moduleNotDefinedMsg =
           String.format(
@@ -161,7 +162,8 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
     if (moduleLimitResult.getResult() == TX_MODULE_LINE_COUNT_OVERFLOW) {
       String txOverflowMsg =
           String.format(
-              "Transaction line count for module %s=%s is above the limit %s",
+              "Transaction %s line count for module %s=%s is above the limit %s",
+              transaction.getHash(),
               moduleLimitResult.getModuleName(),
               moduleLimitResult.getModuleLineCount(),
               moduleLimitResult.getModuleLineLimit());

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
@@ -161,6 +161,7 @@ public class SimulationValidatorTest {
             .signature(FAKE_SIGNATURE)
             .build();
     assertThat(simulationValidator.validateTransaction(transaction, true, false))
-        .contains("Transaction line count for module EXT=7 is above the limit 5");
+        .contains(
+            "Transaction 0xbf668c5dc926c008d5b34f347e1842b94911b46f4a36b668812f821e20303322 line count for module EXT=7 is above the limit 5");
   }
 }


### PR DESCRIPTION
tx hash might be obtainable from existing logs but it is currently only printed at TRACE https://github.com/Consensys/linea-sequencer/blob/d9f2a69ddf6340d3e442b342891513d3e4d9ef7e/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java#L135-L138