### PR TITLE
Update arithmetization dependency version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-releaseVersion=0.6.0-rc3.1
+releaseVersion=0.6.0-rc5.1
 besuVersion=24.9-delivery32
-arithmetizationVersion=0.6.0-rc3
+arithmetizationVersion=0.6.0-rc5
 besuArtifactGroup=io.consensys.linea-besu
 distributionIdentifier=linea-sequencer
 distributionBaseUrl=https://artifacts.consensys.net/public/linea-besu/raw/names/linea-besu.tar.gz/versions/


### PR DESCRIPTION
Update arithmetization dependency version to 0.6.0-rc5, to create a new release.