### PR TITLE
feat: Report rejected transactions to an external service for tx pool validators used by LineaTransactionPoolValidatorPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Next release
-* feat: Report rejected transactions to an external service for SimulationValidator used by LineaTransactionPoolValidatorPlugin [#85](https://github.com/Consensys/linea-sequencer/pull/85)
+* feat: Report rejected transactions to an external service for validators used by LineaTransactionPoolValidatorPlugin [#85](https://github.com/Consensys/linea-sequencer/pull/85)
 * feat: Report rejected transactions to an external service for LineaTransactionSelector used by LineaTransactionSelectorPlugin [#69](https://github.com/Consensys/linea-sequencer/pull/69)
 
 ## 0.6.0-rc1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Next release
-* feat: Report rejected transactions to an external service for SimulationValidator used by LineaTransactionPoolValidatorPlugin [#85](https://github.com/Consensys/linea-sequencer/pull/69)
+* feat: Report rejected transactions to an external service for SimulationValidator used by LineaTransactionPoolValidatorPlugin [#85](https://github.com/Consensys/linea-sequencer/pull/85)
 * feat: Report rejected transactions to an external service for LineaTransactionSelector used by LineaTransactionSelectorPlugin [#69](https://github.com/Consensys/linea-sequencer/pull/69)
 
 ## 0.6.0-rc1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Next release
-* feat: Report rejected transactions to an external service [#69](https://github.com/Consensys/linea-sequencer/pull/69)
+* feat: Report rejected transactions to an external service for SimulationValidator used by LineaTransactionPoolValidatorPlugin [#85](https://github.com/Consensys/linea-sequencer/pull/69)
+* feat: Report rejected transactions to an external service for LineaTransactionSelector used by LineaTransactionSelectorPlugin [#69](https://github.com/Consensys/linea-sequencer/pull/69)
 
 ## 0.6.0-rc1.1
 * bump linea-arithmetization version to 0.6.0-rc1 [#71](https://github.com/Consensys/linea-sequencer/pull/71)

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -78,6 +78,7 @@ dependencyManagement {
       entry "dsl"
       entry "eth"
       entry "rlp"
+      entry "besu"
     }
 
     dependencySet(group: 'ch.qos.logback', version: '1.5.6') {

--- a/sequencer/build.gradle
+++ b/sequencer/build.gradle
@@ -69,8 +69,8 @@ dependencies {
   testImplementation "${besuArtifactGroup}:besu-datatypes"
   testImplementation "${besuArtifactGroup}.internal:core"
   testImplementation "${besuArtifactGroup}.internal:rlp"
-  testImplementation "${besuArtifactGroup}.internal:core"
   testImplementation "${besuArtifactGroup}:plugin-api"
+  testImplementation "${besuArtifactGroup}.internal:besu"
   testImplementation "org.awaitility:awaitility"
 
   // workaround for bug https://github.com/dnsjava/dnsjava/issues/329, remove when upgraded upstream

--- a/sequencer/src/main/java/net/consensys/linea/AbstractLineaPrivateOptionsPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/AbstractLineaPrivateOptionsPlugin.java
@@ -22,6 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.compress.LibCompress;
 import net.consensys.linea.config.LineaProfitabilityCliOptions;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
+import net.consensys.linea.config.LineaRejectedTxReportingCliOptions;
+import net.consensys.linea.config.LineaRejectedTxReportingConfiguration;
 import net.consensys.linea.config.LineaRpcCliOptions;
 import net.consensys.linea.config.LineaRpcConfiguration;
 import net.consensys.linea.config.LineaTracerCliOptions;
@@ -68,6 +70,9 @@ public abstract class AbstractLineaPrivateOptionsPlugin extends AbstractLineaSha
     configMap.put(
         LineaTracerCliOptions.CONFIG_KEY, LineaTracerCliOptions.create().asPluginConfig());
 
+    configMap.put(
+        LineaRejectedTxReportingCliOptions.CONFIG_KEY,
+        LineaRejectedTxReportingCliOptions.create().asPluginConfig());
     return configMap;
   }
 
@@ -94,6 +99,11 @@ public abstract class AbstractLineaPrivateOptionsPlugin extends AbstractLineaSha
   public LineaTracerConfiguration tracerConfiguration() {
     return (LineaTracerConfiguration)
         getConfigurationByKey(LineaTracerCliOptions.CONFIG_KEY).optionsConfig();
+  }
+
+  public LineaRejectedTxReportingConfiguration rejectedTxReportingConfiguration() {
+    return (LineaRejectedTxReportingConfiguration)
+        getConfigurationByKey(LineaRejectedTxReportingCliOptions.CONFIG_KEY).optionsConfig();
   }
 
   @Override

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaNodeType.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaNodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package net.consensys.linea.config;
 
 public enum LineaNodeType {

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaNodeType.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaNodeType.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.config;
 
+/** Linea node type that is used when reporting rejected transactions. */
 public enum LineaNodeType {
   SEQUENCER,
   RPC,

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaNodeType.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaNodeType.java
@@ -1,0 +1,7 @@
+package net.consensys.linea.config;
+
+public enum LineaNodeType {
+  SEQUENCER,
+  RPC,
+  P2P
+}

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingCliOptions.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingCliOptions.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.config;
+
+import java.net.URI;
+
+import com.google.common.base.MoreObjects;
+import net.consensys.linea.plugins.LineaCliOptions;
+import picocli.CommandLine;
+
+/** The Linea Rejected Transaction Reporting CLI options. */
+public class LineaRejectedTxReportingCliOptions implements LineaCliOptions {
+  /**
+   * The configuration key used in AbstractLineaPrivateOptionsPlugin to identify the cli options.
+   */
+  public static final String CONFIG_KEY = "rejected-tx-reporting-config";
+
+  /** The rejected transaction endpoint. */
+  public static final String REJECTED_TX_ENDPOINT = "--plugin-linea-rejected-tx-endpoint";
+
+  @CommandLine.Option(
+      names = {REJECTED_TX_ENDPOINT},
+      hidden = true,
+      paramLabel = "<URI>",
+      description =
+          "Endpoint URI for reporting rejected transactions. Specify a valid URI to enable reporting.")
+  private URI rejectedTxEndpoint = null;
+
+  /** Default constructor. */
+  private LineaRejectedTxReportingCliOptions() {}
+
+  /**
+   * Create Linea Rejected Transaction Reporting CLI options.
+   *
+   * @return the Linea Rejected Transaction Reporting CLI options
+   */
+  public static LineaRejectedTxReportingCliOptions create() {
+    return new LineaRejectedTxReportingCliOptions();
+  }
+
+  /**
+   * Instantiates a new Linea rejected tx reporting cli options from Configuration object
+   *
+   * @param config An instance of LineaRejectedTxReportingConfiguration
+   */
+  public static LineaRejectedTxReportingCliOptions fromConfig(
+      final LineaRejectedTxReportingConfiguration config) {
+    final LineaRejectedTxReportingCliOptions options = create();
+    options.rejectedTxEndpoint = config.rejectedTxEndpoint();
+    return options;
+  }
+
+  @Override
+  public LineaRejectedTxReportingConfiguration toDomainObject() {
+    return LineaRejectedTxReportingConfiguration.builder()
+        .rejectedTxEndpoint(rejectedTxEndpoint)
+        .build();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add(REJECTED_TX_ENDPOINT, rejectedTxEndpoint)
+        .toString();
+  }
+}

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingCliOptions.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingCliOptions.java
@@ -14,7 +14,7 @@
  */
 package net.consensys.linea.config;
 
-import java.net.URI;
+import java.net.URL;
 import java.util.Optional;
 
 import com.google.common.base.MoreObjects;
@@ -43,10 +43,10 @@ public class LineaRejectedTxReportingCliOptions implements LineaCliOptions {
         names = {REJECTED_TX_ENDPOINT},
         hidden = true,
         required = true, // required within the group
-        paramLabel = "<URI>",
+        paramLabel = "<URL>",
         description =
             "Endpoint URI for reporting rejected transactions. Specify a valid URI to enable reporting.")
-    URI rejectedTxEndpoint = null;
+    URL rejectedTxEndpoint = null;
 
     @Option(
         names = {LINEA_NODE_TYPE},
@@ -85,6 +85,7 @@ public class LineaRejectedTxReportingCliOptions implements LineaCliOptions {
       depOpts.lineaNodeType = config.lineaNodeType();
       options.dependentOptions = depOpts;
     }
+
     return options;
   }
 

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingCliOptions.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingCliOptions.java
@@ -30,6 +30,9 @@ public class LineaRejectedTxReportingCliOptions implements LineaCliOptions {
   /** The rejected transaction endpoint. */
   public static final String REJECTED_TX_ENDPOINT = "--plugin-linea-rejected-tx-endpoint";
 
+  /** The Linea node type. */
+  public static final String LINEA_NODE_TYPE = "--plugin-linea-node-type";
+
   @CommandLine.Option(
       names = {REJECTED_TX_ENDPOINT},
       hidden = true,
@@ -37,6 +40,14 @@ public class LineaRejectedTxReportingCliOptions implements LineaCliOptions {
       description =
           "Endpoint URI for reporting rejected transactions. Specify a valid URI to enable reporting.")
   private URI rejectedTxEndpoint = null;
+
+  @CommandLine.Option(
+      names = {LINEA_NODE_TYPE},
+      hidden = true,
+      paramLabel = "<NODE_TYPE>",
+      description =
+          "Linea Node type to use when reporting rejected transactions. (default: ${DEFAULT-VALUE}. Valid values: ${COMPLETION-CANDIDATES})")
+  private LineaNodeType lineaNodeType = LineaNodeType.SEQUENCER;
 
   /** Default constructor. */
   private LineaRejectedTxReportingCliOptions() {}
@@ -59,6 +70,7 @@ public class LineaRejectedTxReportingCliOptions implements LineaCliOptions {
       final LineaRejectedTxReportingConfiguration config) {
     final LineaRejectedTxReportingCliOptions options = create();
     options.rejectedTxEndpoint = config.rejectedTxEndpoint();
+    options.lineaNodeType = config.lineaNodeType();
     return options;
   }
 
@@ -66,6 +78,7 @@ public class LineaRejectedTxReportingCliOptions implements LineaCliOptions {
   public LineaRejectedTxReportingConfiguration toDomainObject() {
     return LineaRejectedTxReportingConfiguration.builder()
         .rejectedTxEndpoint(rejectedTxEndpoint)
+        .lineaNodeType(lineaNodeType)
         .build();
   }
 
@@ -73,6 +86,7 @@ public class LineaRejectedTxReportingCliOptions implements LineaCliOptions {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add(REJECTED_TX_ENDPOINT, rejectedTxEndpoint)
+        .add(LINEA_NODE_TYPE, lineaNodeType)
         .toString();
   }
 }

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingConfiguration.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingConfiguration.java
@@ -22,5 +22,5 @@ import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
 /** The Linea RPC configuration. */
 @Builder(toBuilder = true)
-public record LineaRejectedTxReportingConfiguration(URI rejectedTxEndpoint)
-    implements LineaOptionsConfiguration {}
+public record LineaRejectedTxReportingConfiguration(
+    URI rejectedTxEndpoint, LineaNodeType lineaNodeType) implements LineaOptionsConfiguration {}

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingConfiguration.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingConfiguration.java
@@ -20,7 +20,7 @@ import java.net.URL;
 import lombok.Builder;
 import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
-/** The Linea RPC configuration. */
+/** Linea Rejected Transactions Reporting Configuration */
 @Builder(toBuilder = true)
 public record LineaRejectedTxReportingConfiguration(
     URL rejectedTxEndpoint, LineaNodeType lineaNodeType) implements LineaOptionsConfiguration {}

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingConfiguration.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingConfiguration.java
@@ -15,7 +15,7 @@
 
 package net.consensys.linea.config;
 
-import java.net.URI;
+import java.net.URL;
 
 import lombok.Builder;
 import net.consensys.linea.plugins.LineaOptionsConfiguration;
@@ -23,4 +23,4 @@ import net.consensys.linea.plugins.LineaOptionsConfiguration;
 /** The Linea RPC configuration. */
 @Builder(toBuilder = true)
 public record LineaRejectedTxReportingConfiguration(
-    URI rejectedTxEndpoint, LineaNodeType lineaNodeType) implements LineaOptionsConfiguration {}
+    URL rejectedTxEndpoint, LineaNodeType lineaNodeType) implements LineaOptionsConfiguration {}

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingConfiguration.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaRejectedTxReportingConfiguration.java
@@ -15,15 +15,12 @@
 
 package net.consensys.linea.config;
 
+import java.net.URI;
+
 import lombok.Builder;
 import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
-/** The Linea transaction selectors configuration. */
+/** The Linea RPC configuration. */
 @Builder(toBuilder = true)
-public record LineaTransactionSelectorConfiguration(
-    int maxBlockCallDataSize,
-    int overLinesLimitCacheSize,
-    long maxGasPerBlock,
-    int unprofitableCacheSize,
-    int unprofitableRetryLimit)
+public record LineaRejectedTxReportingConfiguration(URI rejectedTxEndpoint)
     implements LineaOptionsConfiguration {}

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionSelectorCliOptions.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionSelectorCliOptions.java
@@ -15,8 +15,6 @@
 
 package net.consensys.linea.config;
 
-import java.net.URI;
-
 import com.google.common.base.MoreObjects;
 import jakarta.validation.constraints.Positive;
 import net.consensys.linea.plugins.LineaCliOptions;
@@ -40,8 +38,6 @@ public class LineaTransactionSelectorCliOptions implements LineaCliOptions {
 
   public static final String UNPROFITABLE_RETRY_LIMIT = "--plugin-linea-unprofitable-retry-limit";
   public static final int DEFAULT_UNPROFITABLE_RETRY_LIMIT = 10;
-
-  public static final String REJECTED_TX_ENDPOINT = "--plugin-linea-rejected-tx-endpoint";
 
   @Positive
   @CommandLine.Option(
@@ -86,13 +82,6 @@ public class LineaTransactionSelectorCliOptions implements LineaCliOptions {
           "Max number of unprofitable transactions we retry on each block creation (default: ${DEFAULT-VALUE})")
   private int unprofitableRetryLimit = DEFAULT_UNPROFITABLE_RETRY_LIMIT;
 
-  @CommandLine.Option(
-      names = {REJECTED_TX_ENDPOINT},
-      hidden = true,
-      paramLabel = "<URI>",
-      description = "Endpoint URI for reporting rejected transactions  (default: ${DEFAULT-VALUE})")
-  private URI rejectedTxEndpoint = null;
-
   private LineaTransactionSelectorCliOptions() {}
 
   /**
@@ -118,7 +107,6 @@ public class LineaTransactionSelectorCliOptions implements LineaCliOptions {
     options.maxGasPerBlock = config.maxGasPerBlock();
     options.unprofitableCacheSize = config.unprofitableCacheSize();
     options.unprofitableRetryLimit = config.unprofitableRetryLimit();
-    options.rejectedTxEndpoint = config.rejectedTxEndpoint();
     return options;
   }
 
@@ -135,7 +123,6 @@ public class LineaTransactionSelectorCliOptions implements LineaCliOptions {
         .maxGasPerBlock(maxGasPerBlock)
         .unprofitableCacheSize(unprofitableCacheSize)
         .unprofitableRetryLimit(unprofitableRetryLimit)
-        .rejectedTxEndpoint(rejectedTxEndpoint)
         .build();
   }
 
@@ -147,7 +134,6 @@ public class LineaTransactionSelectorCliOptions implements LineaCliOptions {
         .add(MAX_GAS_PER_BLOCK, maxGasPerBlock)
         .add(UNPROFITABLE_CACHE_SIZE, unprofitableCacheSize)
         .add(UNPROFITABLE_RETRY_LIMIT, unprofitableRetryLimit)
-        .add(REJECTED_TX_ENDPOINT, rejectedTxEndpoint)
         .toString();
   }
 }

--- a/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcManager.java
+++ b/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcManager.java
@@ -17,7 +17,6 @@ package net.consensys.linea.jsonrpc;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.MalformedURLException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -222,17 +221,9 @@ public class JsonRpcManager {
   private boolean sendJsonRpcCall(final String jsonContent) {
     final RequestBody body = RequestBody.create(jsonContent, JSON);
     final Request request;
-    try {
-      request =
-          new Request.Builder()
-              .url(reportingConfiguration.rejectedTxEndpoint().toURL())
-              .post(body)
-              .build();
-    } catch (final MalformedURLException e) {
-      log.error(
-          "Invalid rejected-tx endpoint URL: {}", reportingConfiguration.rejectedTxEndpoint(), e);
-      return false;
-    }
+
+    request =
+        new Request.Builder().url(reportingConfiguration.rejectedTxEndpoint()).post(body).build();
 
     try (final Response response = client.newCall(request).execute()) {
       if (!response.isSuccessful()) {

--- a/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcManager.java
+++ b/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcManager.java
@@ -234,9 +234,7 @@ public class JsonRpcManager {
 
   private boolean sendJsonRpcCall(final String jsonContent) {
     final RequestBody body = RequestBody.create(jsonContent, JSON);
-    final Request request;
-
-    request =
+    final Request request =
         new Request.Builder().url(reportingConfiguration.rejectedTxEndpoint()).post(body).build();
 
     try (final Response response = client.newCall(request).execute()) {

--- a/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcManager.java
+++ b/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcManager.java
@@ -54,12 +54,14 @@ public class JsonRpcManager {
   private static final Duration INITIAL_RETRY_DELAY_DURATION = Duration.ofSeconds(1);
   private static final Duration MAX_RETRY_DURATION = Duration.ofHours(2);
   private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+  static final String JSON_RPC_DIR = "rej-tx-rpc";
+  static final String DISCARDED_DIR = "discarded";
 
   private final OkHttpClient client = new OkHttpClient();
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final Map<Path, Instant> fileStartTimes = new ConcurrentHashMap<>();
 
-  private final Path rejTxRpcDirectory;
+  private final Path jsonRpcDir;
   private final LineaRejectedTxReportingConfiguration reportingConfiguration;
   private final ExecutorService executorService;
   private final ScheduledExecutorService retrySchedulerService;
@@ -67,18 +69,21 @@ public class JsonRpcManager {
   /**
    * Creates a new JSON-RPC manager.
    *
+   * @param pluginIdentifier The plugin identifier will be created as a sub-directory under
+   *     rej-tx-rpc. The rejected transactions will be stored under it for each plugin that uses it.
    * @param besuDataDir Path to Besu data directory. The json-rpc files will be stored here under
    *     rej-tx-rpc subdirectory.
    * @param reportingConfiguration Instance of LineaRejectedTxReportingConfiguration containing the
    *     endpoint URI and node type.
    */
   public JsonRpcManager(
+      @NonNull final String pluginIdentifier,
       @NonNull final Path besuDataDir,
       @NonNull final LineaRejectedTxReportingConfiguration reportingConfiguration) {
     if (reportingConfiguration.rejectedTxEndpoint() == null) {
       throw new IllegalStateException("Rejected transaction endpoint URI is required");
     }
-    this.rejTxRpcDirectory = besuDataDir.resolve("rej_tx_rpc");
+    this.jsonRpcDir = besuDataDir.resolve(JSON_RPC_DIR).resolve(pluginIdentifier);
     this.reportingConfiguration = reportingConfiguration;
     this.executorService = Executors.newVirtualThreadPerTaskExecutor();
     this.retrySchedulerService = Executors.newSingleThreadScheduledExecutor();
@@ -87,14 +92,14 @@ public class JsonRpcManager {
   /** Load existing JSON-RPC and submit them. */
   public JsonRpcManager start() {
     try {
-      // Create the rej_tx_rpc/discarded directories if it doesn't exist
-      Files.createDirectories(rejTxRpcDirectory.resolve("discarded"));
+      // Create the rej-tx-rpc/pluginIdentifier/discarded directories if it doesn't exist
+      Files.createDirectories(jsonRpcDir.resolve(DISCARDED_DIR));
 
       // Load existing JSON files
       processExistingJsonFiles();
       return this;
     } catch (final IOException e) {
-      log.error("Failed to create or access directory: {}", rejTxRpcDirectory, e);
+      log.error("Failed to create or access directories under: {}", jsonRpcDir, e);
       throw new UncheckedIOException(e);
     }
   }
@@ -113,7 +118,7 @@ public class JsonRpcManager {
   public void submitNewJsonRpcCall(final String jsonContent) {
     final Path jsonFile;
     try {
-      jsonFile = saveJsonToDir(jsonContent, rejTxRpcDirectory);
+      jsonFile = saveJsonToDir(jsonContent, jsonRpcDir);
     } catch (final IOException e) {
       log.error("Failed to save JSON-RPC content", e);
       return;
@@ -131,8 +136,7 @@ public class JsonRpcManager {
     try {
       final TreeSet<Path> sortedFiles = new TreeSet<>(Comparator.comparing(Path::getFileName));
 
-      try (DirectoryStream<Path> stream =
-          Files.newDirectoryStream(rejTxRpcDirectory, "rpc_*.json")) {
+      try (DirectoryStream<Path> stream = Files.newDirectoryStream(jsonRpcDir, "rpc_*.json")) {
         for (Path path : stream) {
           sortedFiles.add(path);
         }
@@ -201,8 +205,7 @@ public class JsonRpcManager {
           TimeUnit.MILLISECONDS);
     } else {
       log.error("Exceeded maximum retry duration for JSON-RPC file: {}.", jsonFile);
-      final Path destination =
-          rejTxRpcDirectory.resolve("discarded").resolve(jsonFile.getFileName());
+      final Path destination = jsonRpcDir.resolve(DISCARDED_DIR).resolve(jsonFile.getFileName());
 
       try {
         Files.move(jsonFile, destination, StandardCopyOption.REPLACE_EXISTING);

--- a/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcRequestBuilder.java
+++ b/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcRequestBuilder.java
@@ -21,11 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.gson.JsonObject;
 import net.consensys.linea.config.LineaNodeType;
-import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.datatypes.Transaction;
-import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
-import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
-import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
 
 /**
  * Helper class to build JSON-RPC requests for rejected transactions.
@@ -53,21 +49,19 @@ import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationCon
 public class JsonRpcRequestBuilder {
   private static final AtomicLong idCounter = new AtomicLong(1);
 
-  public static String buildRejectedTxRequest(
-      final TransactionEvaluationContext<? extends PendingTransaction> evaluationContext,
-      final TransactionSelectionResult transactionSelectionResult,
-      final Instant timestamp) {
-    final PendingTransaction pendingTransaction = evaluationContext.getPendingTransaction();
-    final ProcessableBlockHeader pendingBlockHeader = evaluationContext.getPendingBlockHeader();
-    return buildRejectedTxRequest(
-        LineaNodeType.SEQUENCER,
-        pendingTransaction.getTransaction(),
-        timestamp,
-        Optional.of(pendingBlockHeader.getNumber()),
-        transactionSelectionResult.maybeInvalidReason().orElse(""));
-  }
-
-  public static String buildRejectedTxRequest(
+  /**
+   * Generate linea_saveRejectedTransactionV1 JSON-RPC request from given arguments.
+   *
+   * @param lineaNodeType Linea node type which is reporting the rejected transaction.
+   * @param transaction The rejected transaction. The encoded transaction RLP is used in the
+   *     JSON-RPC request.
+   * @param timestamp The timestamp when the transaction was rejected.
+   * @param blockNumber Optional block number where the transaction was rejected. Used for sequencer
+   *     node.
+   * @param reasonMessage The reason message for the rejection.
+   * @return JSON-RPC request as a string.
+   */
+  public static String generateSaveRejectedTxJsonRpc(
       final LineaNodeType lineaNodeType,
       final Transaction transaction,
       final Instant timestamp,

--- a/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcRequestBuilder.java
+++ b/sequencer/src/main/java/net/consensys/linea/jsonrpc/JsonRpcRequestBuilder.java
@@ -16,56 +16,70 @@
 package net.consensys.linea.jsonrpc;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.gson.JsonObject;
+import net.consensys.linea.config.LineaNodeType;
 import org.hyperledger.besu.datatypes.PendingTransaction;
+import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
 
-/** Helper class to build JSON-RPC requests for rejected transactions. */
+/**
+ * Helper class to build JSON-RPC requests for rejected transactions.
+ *
+ * <pre>
+ * {@code linea_saveRejectedTransactionV1({
+ *         "txRejectionStage": "SEQUENCER/RPC/P2P",
+ *         "timestamp": "2024-08-22T09:18:51Z", # ISO8601 UTC+0 when tx was rejected by node, usefull if P2P edge node.
+ *         "blockNumber": "base 10 number",
+ *         "transactionRLP": "transaction as the user sent in eth_sendRawTransaction",
+ *         "reason": "Transaction line count for module ADD=402 is above the limit 70"
+ *         "overflows": [{
+ *           "module": "ADD",
+ *           "count": 402,
+ *           "limit": 70
+ *         }, {
+ *           "module": "MUL",
+ *           "count": 587,
+ *           "limit": 400
+ *         }]
+ *     })
+ * }
+ * </pre>
+ */
 public class JsonRpcRequestBuilder {
   private static final AtomicLong idCounter = new AtomicLong(1);
 
-  /**
-   *
-   *
-   * <pre>
-   * {@code linea_saveRejectedTransactionV1({
-   *         "txRejectionStage": "SEQUENCER/RPC/P2P",
-   *         "timestamp": "2024-08-22T09:18:51Z", # ISO8601 UTC+0 when tx was rejected by node, usefull if P2P edge node.
-   *         "blockNumber": "base 10 number",
-   *         "transactionRLP": "transaction as the user sent in eth_sendRawTransaction",
-   *         "reason": "Transaction line count for module ADD=402 is above the limit 70"
-   *         "overflows": [{
-   *           "module": "ADD",
-   *           "count": 402,
-   *           "limit": 70
-   *         }, {
-   *           "module": "MUL",
-   *           "count": 587,
-   *           "limit": 400
-   *         }]
-   *     })
-   * }
-   * </pre>
-   */
   public static String buildRejectedTxRequest(
       final TransactionEvaluationContext<? extends PendingTransaction> evaluationContext,
       final TransactionSelectionResult transactionSelectionResult,
       final Instant timestamp) {
     final PendingTransaction pendingTransaction = evaluationContext.getPendingTransaction();
     final ProcessableBlockHeader pendingBlockHeader = evaluationContext.getPendingBlockHeader();
+    return buildRejectedTxRequest(
+        LineaNodeType.SEQUENCER,
+        pendingTransaction.getTransaction(),
+        timestamp,
+        Optional.of(pendingBlockHeader.getNumber()),
+        transactionSelectionResult.maybeInvalidReason().orElse(""));
+  }
 
-    // Build JSON-RPC request
+  public static String buildRejectedTxRequest(
+      final LineaNodeType lineaNodeType,
+      final Transaction transaction,
+      final Instant timestamp,
+      final Optional<Long> blockNumber,
+      final String reasonMessage) {
     final JsonObject params = new JsonObject();
-    params.addProperty("txRejectionStage", "SEQUENCER");
+    params.addProperty("txRejectionStage", lineaNodeType.name());
     params.addProperty("timestamp", timestamp.toString());
-    params.addProperty("blockNumber", pendingBlockHeader.getNumber());
-    params.addProperty(
-        "transactionRLP", pendingTransaction.getTransaction().encoded().toHexString());
-    params.addProperty("reasonMessage", transactionSelectionResult.maybeInvalidReason().orElse(""));
+    blockNumber.ifPresent(number -> params.addProperty("blockNumber", number));
+    params.addProperty("transactionRLP", transaction.encoded().toHexString());
+    params.addProperty("reasonMessage", reasonMessage);
+    // TODO: overflows
 
     final JsonObject request = new JsonObject();
     request.addProperty("jsonrpc", "2.0");

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
@@ -80,10 +80,11 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
   public PluginTransactionPoolValidator createTransactionValidator() {
     final var validators =
         new PluginTransactionPoolValidator[] {
-          new AllowedAddressValidator(denied),
-          new GasLimitValidator(txPoolValidatorConf),
-          new CalldataValidator(txPoolValidatorConf),
-          new ProfitabilityValidator(besuConfiguration, blockchainService, profitabilityConf),
+          new AllowedAddressValidator(denied, rejectedTxJsonRpcManager),
+          new GasLimitValidator(txPoolValidatorConf, rejectedTxJsonRpcManager),
+          new CalldataValidator(txPoolValidatorConf, rejectedTxJsonRpcManager),
+          new ProfitabilityValidator(
+              besuConfiguration, blockchainService, profitabilityConf, rejectedTxJsonRpcManager),
           new SimulationValidator(
               blockchainService,
               transactionSimulationService,

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
 import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
+import net.consensys.linea.jsonrpc.JsonRpcManager;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
 import net.consensys.linea.sequencer.txpoolvalidation.validators.AllowedAddressValidator;
 import net.consensys.linea.sequencer.txpoolvalidation.validators.CalldataValidator;
@@ -46,6 +47,7 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
   private final Set<Address> denied;
   private final Map<String, Integer> moduleLineLimitsMap;
   private final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration;
+  private final Optional<JsonRpcManager> rejectedTxJsonRpcManager;
 
   public LineaTransactionPoolValidatorFactory(
       final BesuConfiguration besuConfiguration,
@@ -55,7 +57,8 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
       final LineaProfitabilityConfiguration profitabilityConf,
       final Set<Address> deniedAddresses,
       final Map<String, Integer> moduleLineLimitsMap,
-      final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration) {
+      final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration,
+      final Optional<JsonRpcManager> rejectedTxJsonRpcManager) {
     this.besuConfiguration = besuConfiguration;
     this.blockchainService = blockchainService;
     this.transactionSimulationService = transactionSimulationService;
@@ -64,6 +67,7 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
     this.denied = deniedAddresses;
     this.moduleLineLimitsMap = moduleLineLimitsMap;
     this.l1L2BridgeConfiguration = l1L2BridgeConfiguration;
+    this.rejectedTxJsonRpcManager = rejectedTxJsonRpcManager;
   }
 
   /**
@@ -85,7 +89,8 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
               transactionSimulationService,
               txPoolValidatorConf,
               moduleLineLimitsMap,
-              l1L2BridgeConfiguration)
+              l1L2BridgeConfiguration,
+              rejectedTxJsonRpcManager)
         };
 
     return (transaction, isLocal, hasPriority) ->

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
@@ -111,6 +111,7 @@ public class LineaTransactionPoolValidatorPlugin extends AbstractLineaRequiredPl
               .map(
                   endpoint ->
                       new JsonRpcManager(
+                              "linea-tx-pool-validator-plugin",
                               besuConfiguration.getDataPath(),
                               lineaRejectedTxReportingConfiguration)
                           .start());

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.AbstractLineaRequiredPlugin;
+import net.consensys.linea.config.LineaRejectedTxReportingConfiguration;
 import net.consensys.linea.jsonrpc.JsonRpcManager;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.plugin.BesuContext;
@@ -103,11 +104,16 @@ public class LineaTransactionPoolValidatorPlugin extends AbstractLineaRequiredPl
           lines.map(l -> Address.fromHexString(l.trim())).collect(Collectors.toUnmodifiableSet());
 
       // start the optional json rpc manager for rejected tx reporting
+      final LineaRejectedTxReportingConfiguration lineaRejectedTxReportingConfiguration =
+          rejectedTxReportingConfiguration();
       rejectedTxJsonRpcManager =
-          Optional.ofNullable(rejectedTxReportingConfiguration().rejectedTxEndpoint())
+          Optional.ofNullable(lineaRejectedTxReportingConfiguration.rejectedTxEndpoint())
               .map(
                   endpoint ->
-                      new JsonRpcManager(besuConfiguration.getDataPath(), endpoint).start());
+                      new JsonRpcManager(
+                              besuConfiguration.getDataPath(),
+                              lineaRejectedTxReportingConfiguration)
+                          .start());
 
       transactionPoolValidatorService.registerPluginTransactionValidatorFactory(
           new LineaTransactionPoolValidatorFactory(

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidator.java
@@ -14,11 +14,15 @@
  */
 package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
+import net.consensys.linea.jsonrpc.JsonRpcManager;
+import net.consensys.linea.jsonrpc.JsonRpcRequestBuilder;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidator;
 
@@ -27,6 +31,7 @@ import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolVal
 @RequiredArgsConstructor
 public class CalldataValidator implements PluginTransactionPoolValidator {
   final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
+  final Optional<JsonRpcManager> rejectedTxJsonRpcManager;
 
   @Override
   public Optional<String> validateTransaction(
@@ -36,8 +41,24 @@ public class CalldataValidator implements PluginTransactionPoolValidator {
           "Calldata of transaction is greater than the allowed max of "
               + txPoolValidatorConf.maxTxCalldataSize();
       log.debug(errMsg);
+      reportRejectedTransaction(transaction, errMsg);
       return Optional.of(errMsg);
     }
     return Optional.empty();
+  }
+
+  private void reportRejectedTransaction(final Transaction transaction, final String reason) {
+    rejectedTxJsonRpcManager.ifPresent(
+        jsonRpcManager -> {
+          final String jsonRpcCall =
+              JsonRpcRequestBuilder.generateSaveRejectedTxJsonRpc(
+                  jsonRpcManager.getNodeType(),
+                  transaction,
+                  Instant.now(),
+                  Optional.empty(), // block number is not available
+                  reason,
+                  List.of());
+          jsonRpcManager.submitNewJsonRpcCallAsync(jsonRpcCall);
+        });
   }
 }

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidator.java
@@ -14,11 +14,15 @@
  */
 package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
+import net.consensys.linea.jsonrpc.JsonRpcManager;
+import net.consensys.linea.jsonrpc.JsonRpcRequestBuilder;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidator;
 
@@ -30,6 +34,7 @@ import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolVal
 @RequiredArgsConstructor
 public class GasLimitValidator implements PluginTransactionPoolValidator {
   final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
+  final Optional<JsonRpcManager> rejectedTxJsonRpcManager;
 
   @Override
   public Optional<String> validateTransaction(
@@ -39,8 +44,24 @@ public class GasLimitValidator implements PluginTransactionPoolValidator {
           "Gas limit of transaction is greater than the allowed max of "
               + txPoolValidatorConf.maxTxGasLimit();
       log.debug(errMsg);
+      reportRejectedTransaction(transaction, errMsg);
       return Optional.of(errMsg);
     }
     return Optional.empty();
+  }
+
+  private void reportRejectedTransaction(final Transaction transaction, final String reason) {
+    rejectedTxJsonRpcManager.ifPresent(
+        jsonRpcManager -> {
+          final String jsonRpcCall =
+              JsonRpcRequestBuilder.generateSaveRejectedTxJsonRpc(
+                  jsonRpcManager.getNodeType(),
+                  transaction,
+                  Instant.now(),
+                  Optional.empty(), // block number is not available
+                  reason,
+                  List.of());
+          jsonRpcManager.submitNewJsonRpcCallAsync(jsonRpcCall);
+        });
   }
 }

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidator.java
@@ -14,11 +14,15 @@
  */
 package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.bl.TransactionProfitabilityCalculator;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
+import net.consensys.linea.jsonrpc.JsonRpcManager;
+import net.consensys.linea.jsonrpc.JsonRpcRequestBuilder;
 import org.apache.tuweni.units.bigints.UInt256s;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.datatypes.Wei;
@@ -37,15 +41,18 @@ public class ProfitabilityValidator implements PluginTransactionPoolValidator {
   final BlockchainService blockchainService;
   final LineaProfitabilityConfiguration profitabilityConf;
   final TransactionProfitabilityCalculator profitabilityCalculator;
+  final Optional<JsonRpcManager> rejectedTxJsonRpcManager;
 
   public ProfitabilityValidator(
       final BesuConfiguration besuConfiguration,
       final BlockchainService blockchainService,
-      final LineaProfitabilityConfiguration profitabilityConf) {
+      final LineaProfitabilityConfiguration profitabilityConf,
+      final Optional<JsonRpcManager> rejectedTxJsonRpcManager) {
     this.besuConfiguration = besuConfiguration;
     this.blockchainService = blockchainService;
     this.profitabilityConf = profitabilityConf;
     this.profitabilityCalculator = new TransactionProfitabilityCalculator(profitabilityConf);
+    this.rejectedTxJsonRpcManager = rejectedTxJsonRpcManager;
   }
 
   @Override
@@ -61,16 +68,19 @@ public class ProfitabilityValidator implements PluginTransactionPoolValidator {
               .getNextBlockBaseFee()
               .orElseThrow(() -> new RuntimeException("We only support a base fee market"));
 
-      return profitabilityCalculator.isProfitable(
-              "Txpool",
-              transaction,
-              profitabilityConf.txPoolMinMargin(),
-              baseFee,
-              calculateUpfrontGasPrice(transaction, baseFee),
-              transaction.getGasLimit(),
-              besuConfiguration.getMinGasPrice())
-          ? Optional.empty()
-          : Optional.of("Gas price too low");
+      final Optional<String> errMsg =
+          profitabilityCalculator.isProfitable(
+                  "Txpool",
+                  transaction,
+                  profitabilityConf.txPoolMinMargin(),
+                  baseFee,
+                  calculateUpfrontGasPrice(transaction, baseFee),
+                  transaction.getGasLimit(),
+                  besuConfiguration.getMinGasPrice())
+              ? Optional.empty()
+              : Optional.of("Gas price too low");
+      errMsg.ifPresent(s -> reportRejectedTransaction(transaction, s));
+      return errMsg;
     }
 
     return Optional.empty();
@@ -87,5 +97,20 @@ public class ProfitabilityValidator implements PluginTransactionPoolValidator {
                     maxFee,
                     baseFee.add(Wei.fromQuantity(transaction.getMaxPriorityFeePerGas().get()))))
         .orElseGet(() -> Wei.fromQuantity(transaction.getGasPrice().get()));
+  }
+
+  private void reportRejectedTransaction(final Transaction transaction, final String reason) {
+    rejectedTxJsonRpcManager.ifPresent(
+        jsonRpcManager -> {
+          final String jsonRpcCall =
+              JsonRpcRequestBuilder.generateSaveRejectedTxJsonRpc(
+                  jsonRpcManager.getNodeType(),
+                  transaction,
+                  Instant.now(),
+                  Optional.empty(), // block number is not available
+                  reason,
+                  List.of());
+          jsonRpcManager.submitNewJsonRpcCallAsync(jsonRpcCall);
+        });
   }
 }

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
+import net.consensys.linea.jsonrpc.JsonRpcManager;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
 import net.consensys.linea.sequencer.modulelimit.ModuleLimitsValidationResult;
 import net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator;
@@ -44,18 +45,21 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
   private final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
   private final Map<String, Integer> moduleLineLimitsMap;
   private final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration;
+  private final Optional<JsonRpcManager> rejectedTxJsonRpcManager;
 
   public SimulationValidator(
       final BlockchainService blockchainService,
       final TransactionSimulationService transactionSimulationService,
       final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf,
       final Map<String, Integer> moduleLineLimitsMap,
-      final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration) {
+      final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration,
+      final Optional<JsonRpcManager> rejectedTxJsonRpcManager) {
     this.blockchainService = blockchainService;
     this.transactionSimulationService = transactionSimulationService;
     this.txPoolValidatorConf = txPoolValidatorConf;
     this.moduleLineLimitsMap = moduleLineLimitsMap;
     this.l1L2BridgeConfiguration = l1L2BridgeConfiguration;
+    this.rejectedTxJsonRpcManager = rejectedTxJsonRpcManager;
   }
 
   @Override
@@ -91,6 +95,11 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
           transaction, isLocal, hasPriority, maybeSimulationResults, moduleLimitResult);
 
       if (moduleLimitResult.getResult() != ModuleLineCountValidator.ModuleLineCountResult.VALID) {
+        // TODO: Report rejected transactions to the JSON-RPC manager
+        rejectedTxJsonRpcManager.ifPresent(
+            jsonRpcManager -> {
+              // jsonRpcManager.submitNewJsonRpcCall
+            });
         return Optional.of(handleModuleOverLimit(transaction, moduleLimitResult));
       }
 
@@ -101,6 +110,11 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
               "Invalid transaction"
                   + simulationResult.getInvalidReason().map(ir -> ": " + ir).orElse("");
           log.debug(errMsg);
+          // TODO: Report rejected transactions to the JSON-RPC manager
+          rejectedTxJsonRpcManager.ifPresent(
+              jsonRpcManager -> {
+                // jsonRpcManager.submitNewJsonRpcCall
+              });
           return Optional.of(errMsg);
         }
         if (!simulationResult.isSuccessful()) {
@@ -111,6 +125,11 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
                       .map(rr -> ": " + rr.toHexString())
                       .orElse("");
           log.debug(errMsg);
+          // TODO: Report rejected transactions to the JSON-RPC manager
+          rejectedTxJsonRpcManager.ifPresent(
+              jsonRpcManager -> {
+                // jsonRpcManager.submitNewJsonRpcCall
+              });
           return Optional.of(errMsg);
         }
       }

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
@@ -18,6 +18,7 @@ import static net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator
 import static net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator.ModuleLineCountResult.TX_MODULE_LINE_COUNT_OVERFLOW;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -108,7 +109,8 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
                       transaction,
                       Instant.now(),
                       Optional.empty(), // block number is not available
-                      reason);
+                      reason,
+                      List.of());
               jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
             });
 
@@ -131,7 +133,8 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
                         transaction,
                         Instant.now(),
                         Optional.empty(), // block number is not available
-                        errMsg);
+                        errMsg,
+                        List.of());
                 jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
               });
           return Optional.of(errMsg);
@@ -153,7 +156,8 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
                         transaction,
                         Instant.now(),
                         Optional.empty(), // block number is not available
-                        errMsg);
+                        errMsg,
+                        List.of());
                 jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
               });
           return Optional.of(errMsg);

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
@@ -149,7 +149,7 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
                   Optional.empty(), // block number is not available
                   reason,
                   List.of());
-          jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
+          jsonRpcManager.submitNewJsonRpcCallAsync(jsonRpcCall);
         });
   }
 

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
@@ -109,7 +109,6 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
                       Instant.now(),
                       Optional.empty(), // block number is not available
                       reason);
-              System.out.println("*** Submitting: " + jsonRpcCall);
               jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
             });
 

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidator.java
@@ -109,6 +109,7 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
                       Instant.now(),
                       Optional.empty(), // block number is not available
                       reason);
+              System.out.println("*** Submitting: " + jsonRpcCall);
               jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
             });
 

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
@@ -82,7 +82,7 @@ public class LineaTransactionSelectorPlugin extends AbstractLineaRequiredPlugin 
     final LineaTransactionSelectorConfiguration txSelectorConfiguration =
         transactionSelectorConfiguration();
     rejectedTxJsonRpcManager =
-        Optional.ofNullable(txSelectorConfiguration.rejectedTxEndpoint())
+        Optional.ofNullable(rejectedTxReportingConfiguration().rejectedTxEndpoint())
             .map(endpoint -> new JsonRpcManager(besuConfiguration.getDataPath(), endpoint).start());
     transactionSelectionService.registerPluginTransactionSelectorFactory(
         new LineaTransactionSelectorFactory(

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
@@ -89,7 +89,9 @@ public class LineaTransactionSelectorPlugin extends AbstractLineaRequiredPlugin 
             .map(
                 endpoint ->
                     new JsonRpcManager(
-                            besuConfiguration.getDataPath(), lineaRejectedTxReportingConfiguration)
+                            "linea-tx-selector-plugin",
+                            besuConfiguration.getDataPath(),
+                            lineaRejectedTxReportingConfiguration)
                         .start());
     transactionSelectionService.registerPluginTransactionSelectorFactory(
         new LineaTransactionSelectorFactory(

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.AbstractLineaRequiredPlugin;
+import net.consensys.linea.config.LineaRejectedTxReportingConfiguration;
 import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import net.consensys.linea.jsonrpc.JsonRpcManager;
 import org.hyperledger.besu.plugin.BesuContext;
@@ -81,9 +82,15 @@ public class LineaTransactionSelectorPlugin extends AbstractLineaRequiredPlugin 
     super.start();
     final LineaTransactionSelectorConfiguration txSelectorConfiguration =
         transactionSelectorConfiguration();
+    final LineaRejectedTxReportingConfiguration lineaRejectedTxReportingConfiguration =
+        rejectedTxReportingConfiguration();
     rejectedTxJsonRpcManager =
-        Optional.ofNullable(rejectedTxReportingConfiguration().rejectedTxEndpoint())
-            .map(endpoint -> new JsonRpcManager(besuConfiguration.getDataPath(), endpoint).start());
+        Optional.ofNullable(lineaRejectedTxReportingConfiguration.rejectedTxEndpoint())
+            .map(
+                endpoint ->
+                    new JsonRpcManager(
+                            besuConfiguration.getDataPath(), lineaRejectedTxReportingConfiguration)
+                        .start());
     transactionSelectionService.registerPluginTransactionSelectorFactory(
         new LineaTransactionSelectorFactory(
             blockchainService,

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -156,6 +156,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
     selectors.forEach(
         selector ->
             selector.onTransactionNotSelected(evaluationContext, transactionSelectionResult));
+
     rejectedTxJsonRpcManager.ifPresent(
         jsonRpcManager -> {
           if (transactionSelectionResult.discard()) {

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -166,7 +166,8 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
                     evaluationContext.getPendingTransaction().getTransaction(),
                     Instant.now(),
                     Optional.of(evaluationContext.getPendingBlockHeader().getNumber()),
-                    transactionSelectionResult.maybeInvalidReason().orElse("")));
+                    transactionSelectionResult.maybeInvalidReason().orElse(""),
+                    List.of()));
           }
         });
   }

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -162,7 +162,11 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
           if (transactionSelectionResult.discard()) {
             jsonRpcManager.submitNewJsonRpcCall(
                 JsonRpcRequestBuilder.buildRejectedTxRequest(
-                    evaluationContext, transactionSelectionResult, Instant.now()));
+                    jsonRpcManager.getNodeType(),
+                    evaluationContext.getPendingTransaction().getTransaction(),
+                    Instant.now(),
+                    Optional.of(evaluationContext.getPendingBlockHeader().getNumber()),
+                    transactionSelectionResult.maybeInvalidReason().orElse("")));
           }
         });
   }

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -156,7 +156,6 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
     selectors.forEach(
         selector ->
             selector.onTransactionNotSelected(evaluationContext, transactionSelectionResult));
-
     rejectedTxJsonRpcManager.ifPresent(
         jsonRpcManager -> {
           if (transactionSelectionResult.discard()) {
@@ -166,7 +165,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
                     evaluationContext.getPendingTransaction().getTransaction(),
                     Instant.now(),
                     Optional.of(evaluationContext.getPendingBlockHeader().getNumber()),
-                    transactionSelectionResult.maybeInvalidReason().orElse(""),
+                    transactionSelectionResult.toString(),
                     List.of()));
           }
         });

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -161,7 +161,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
         jsonRpcManager -> {
           if (transactionSelectionResult.discard()) {
             jsonRpcManager.submitNewJsonRpcCall(
-                JsonRpcRequestBuilder.buildRejectedTxRequest(
+                JsonRpcRequestBuilder.generateSaveRejectedTxJsonRpc(
                     jsonRpcManager.getNodeType(),
                     evaluationContext.getPendingTransaction().getTransaction(),
                     Instant.now(),

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -160,7 +160,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
     rejectedTxJsonRpcManager.ifPresent(
         jsonRpcManager -> {
           if (transactionSelectionResult.discard()) {
-            jsonRpcManager.submitNewJsonRpcCall(
+            jsonRpcManager.submitNewJsonRpcCallAsync(
                 JsonRpcRequestBuilder.generateSaveRejectedTxJsonRpc(
                     jsonRpcManager.getNodeType(),
                     evaluationContext.getPendingTransaction().getTransaction(),

--- a/sequencer/src/test/java/net/consensys/linea/config/LineaRejectedTxReportingCliOptionsTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/config/LineaRejectedTxReportingCliOptionsTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+import org.hyperledger.besu.services.PicoCLIOptionsImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+class LineaRejectedTxReportingCliOptionsTest {
+
+  @Command
+  static final class MockLineaBesuCommand {
+    @Option(names = "--mock-option")
+    String mockOption;
+  }
+
+  private MockLineaBesuCommand command;
+  private LineaRejectedTxReportingCliOptions lineaRejectedTxReportingCliOptions;
+  private CommandLine commandLine;
+  private PicoCLIOptions picoCliService;
+
+  @BeforeEach
+  public void setup() {
+    command = new MockLineaBesuCommand();
+    commandLine = new CommandLine(command);
+    picoCliService = new PicoCLIOptionsImpl(commandLine);
+
+    lineaRejectedTxReportingCliOptions = LineaRejectedTxReportingCliOptions.create();
+    picoCliService.addPicoCLIOptions("linea", lineaRejectedTxReportingCliOptions);
+  }
+
+  @Test
+  void emptyLineaRejectedTxReportingCliOptions() {
+    commandLine.parseArgs("--mock-option", "mockValue");
+
+    assertThat(command.mockOption).isEqualTo("mockValue");
+    assertThat(lineaRejectedTxReportingCliOptions.dependentOptions).isNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(LineaNodeType.class)
+  void lineaRejectedTxOptionBothOptionsRequired(final LineaNodeType lineaNodeType)
+      throws MalformedURLException {
+    commandLine.parseArgs(
+        "--plugin-linea-rejected-tx-endpoint",
+        "http://localhost:8080",
+        "--plugin-linea-node-type",
+        lineaNodeType.name());
+
+    assertThat(lineaRejectedTxReportingCliOptions.dependentOptions.rejectedTxEndpoint)
+        .isEqualTo(URI.create("http://localhost:8080").toURL());
+    assertThat(lineaRejectedTxReportingCliOptions.dependentOptions.lineaNodeType)
+        .isEqualTo(lineaNodeType);
+  }
+
+  @Test
+  void lineaRejectedTxReportingCliOptionsOnlyEndpointCauseException() {
+    assertThatExceptionOfType(CommandLine.ParameterException.class)
+        .isThrownBy(
+            () ->
+                commandLine.parseArgs(
+                    "--plugin-linea-rejected-tx-endpoint", "http://localhost:8080"))
+        .withMessageContaining(
+            "Error: Missing required argument(s): --plugin-linea-node-type=<NODE_TYPE>");
+  }
+
+  @Test
+  void lineaRejectedTxReportingCliOptionsOnlyNodeTypeCauseException() {
+    assertThatExceptionOfType(CommandLine.ParameterException.class)
+        .isThrownBy(
+            () -> commandLine.parseArgs("--plugin-linea-node-type", LineaNodeType.SEQUENCER.name()))
+        .withMessageContaining(
+            "Error: Missing required argument(s): --plugin-linea-rejected-tx-endpoint=<URL>");
+  }
+
+  @Test
+  void lineaRejectedTxReportingInvalidNodeTypeCauseException() {
+    assertThatExceptionOfType(CommandLine.ParameterException.class)
+        .isThrownBy(
+            () ->
+                commandLine.parseArgs(
+                    "--plugin-linea-rejected-tx-endpoint",
+                    "http://localhost:8080",
+                    "--plugin-linea-node-type",
+                    "INVALID_NODE_TYPE"))
+        .withMessageContaining(
+            "Invalid value for option '--plugin-linea-node-type': expected one of [SEQUENCER, RPC, P2P] (case-sensitive) but was 'INVALID_NODE_TYPE'");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "http://localhost:8080:8080", "invalid"})
+  void lineaRejectedTxReportingCliOptionsInvalidEndpointCauseException(final String endpoint) {
+    assertThatExceptionOfType(CommandLine.ParameterException.class)
+        .isThrownBy(
+            () ->
+                commandLine.parseArgs(
+                    "--plugin-linea-rejected-tx-endpoint",
+                    endpoint,
+                    "--plugin-linea-node-type",
+                    "SEQUENCER"))
+        .withMessageContaining(
+            "Invalid value for option '--plugin-linea-rejected-tx-endpoint': cannot convert '"
+                + endpoint
+                + "' to URL (java.net.MalformedURLException:");
+  }
+}

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -75,7 +76,8 @@ public class JsonRpcManagerStartTest {
               transaction,
               timestamp,
               Optional.of(1L),
-              result.maybeInvalidReason().orElse(""));
+              result.maybeInvalidReason().orElse(""),
+              List.of());
 
       JsonRpcManager.saveJsonToDir(jsonRpcCall, rejectedTxDir);
     }

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
@@ -76,7 +76,7 @@ public class JsonRpcManagerStartTest {
               transaction,
               timestamp,
               Optional.of(1L),
-              result.maybeInvalidReason().orElse(""),
+              result.toString(),
               List.of());
 
       JsonRpcManager.saveJsonToDir(jsonRpcCall, rejectedTxDir);

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
@@ -55,12 +55,14 @@ public class JsonRpcManagerStartTest {
   private JsonRpcManager jsonRpcManager;
   private final Bytes randomEncodedBytes = Bytes.random(32);
   @Mock private Transaction transaction;
+  static final String PLUGIN_IDENTIFIER = "linea-start-test-plugin";
 
   @BeforeEach
   void init(final WireMockRuntimeInfo wmInfo) throws IOException {
     // create temp directories
-    final Path rejectedTxDir = tempDataDir.resolve("rej_tx_rpc");
-    Files.createDirectories(rejectedTxDir);
+    final Path jsonRpcDir =
+        tempDataDir.resolve(JsonRpcManager.JSON_RPC_DIR).resolve(PLUGIN_IDENTIFIER);
+    Files.createDirectories(jsonRpcDir);
 
     // mock stubbing
     when(transaction.encoded()).thenReturn(randomEncodedBytes);
@@ -79,7 +81,7 @@ public class JsonRpcManagerStartTest {
               result.toString(),
               List.of());
 
-      JsonRpcManager.saveJsonToDir(jsonRpcCall, rejectedTxDir);
+      JsonRpcManager.saveJsonToDir(jsonRpcCall, jsonRpcDir);
     }
 
     final LineaRejectedTxReportingConfiguration config =
@@ -87,7 +89,7 @@ public class JsonRpcManagerStartTest {
             .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()).toURL())
             .lineaNodeType(LineaNodeType.SEQUENCER)
             .build();
-    jsonRpcManager = new JsonRpcManager(tempDataDir, config);
+    jsonRpcManager = new JsonRpcManager(PLUGIN_IDENTIFIER, tempDataDir, config);
   }
 
   @AfterEach

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
@@ -33,6 +33,8 @@ import java.time.Instant;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import net.consensys.linea.config.LineaNodeType;
+import net.consensys.linea.config.LineaRejectedTxReportingConfiguration;
 import net.consensys.linea.sequencer.txselection.selectors.TestTransactionEvaluationContext;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.PendingTransaction;
@@ -81,7 +83,12 @@ public class JsonRpcManagerStartTest {
       JsonRpcManager.saveJsonToDir(jsonRpcCall, rejectedTxDir);
     }
 
-    jsonRpcManager = new JsonRpcManager(tempDataDir, URI.create(wmInfo.getHttpBaseUrl()));
+    final LineaRejectedTxReportingConfiguration config =
+        LineaRejectedTxReportingConfiguration.builder()
+            .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()))
+            .lineaNodeType(LineaNodeType.SEQUENCER)
+            .build();
+    jsonRpcManager = new JsonRpcManager(tempDataDir, config);
   }
 
   @AfterEach

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
@@ -30,16 +30,14 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Optional;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import net.consensys.linea.config.LineaNodeType;
 import net.consensys.linea.config.LineaRejectedTxReportingConfiguration;
-import net.consensys.linea.sequencer.txselection.selectors.TestTransactionEvaluationContext;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.datatypes.Transaction;
-import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,8 +53,6 @@ public class JsonRpcManagerStartTest {
   @TempDir private Path tempDataDir;
   private JsonRpcManager jsonRpcManager;
   private final Bytes randomEncodedBytes = Bytes.random(32);
-  @Mock private PendingTransaction pendingTransaction;
-  @Mock private ProcessableBlockHeader pendingBlockHeader;
   @Mock private Transaction transaction;
 
   @BeforeEach
@@ -66,19 +62,20 @@ public class JsonRpcManagerStartTest {
     Files.createDirectories(rejectedTxDir);
 
     // mock stubbing
-    when(pendingBlockHeader.getNumber()).thenReturn(1L);
-    when(pendingTransaction.getTransaction()).thenReturn(transaction);
     when(transaction.encoded()).thenReturn(randomEncodedBytes);
 
     // save rejected transaction in tempDataDir so that they are processed by the
     // JsonRpcManager.start
     for (int i = 0; i < 3; i++) {
-      final TestTransactionEvaluationContext context =
-          new TestTransactionEvaluationContext(pendingBlockHeader, pendingTransaction);
       final TransactionSelectionResult result = TransactionSelectionResult.invalid("test" + i);
       final Instant timestamp = Instant.now();
       final String jsonRpcCall =
-          JsonRpcRequestBuilder.buildRejectedTxRequest(context, result, timestamp);
+          JsonRpcRequestBuilder.generateSaveRejectedTxJsonRpc(
+              LineaNodeType.SEQUENCER,
+              transaction,
+              timestamp,
+              Optional.of(1L),
+              result.maybeInvalidReason().orElse(""));
 
       JsonRpcManager.saveJsonToDir(jsonRpcCall, rejectedTxDir);
     }
@@ -97,7 +94,7 @@ public class JsonRpcManagerStartTest {
   }
 
   @Test
-  void existingJsonRpcFilesAreProcessedOnStart() throws InterruptedException {
+  void existingJsonRpcFilesAreProcessedOnStart() {
     stubFor(
         post(urlEqualTo("/"))
             .willReturn(

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerStartTest.java
@@ -84,7 +84,7 @@ public class JsonRpcManagerStartTest {
 
     final LineaRejectedTxReportingConfiguration config =
         LineaRejectedTxReportingConfiguration.builder()
-            .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()))
+            .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()).toURL())
             .lineaNodeType(LineaNodeType.SEQUENCER)
             .build();
     jsonRpcManager = new JsonRpcManager(tempDataDir, config);

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
@@ -39,6 +39,8 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import net.consensys.linea.config.LineaNodeType;
+import net.consensys.linea.config.LineaRejectedTxReportingConfiguration;
 import net.consensys.linea.sequencer.txselection.selectors.TestTransactionEvaluationContext;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.PendingTransaction;
@@ -69,8 +71,12 @@ class JsonRpcManagerTest {
     when(pendingBlockHeader.getNumber()).thenReturn(1L);
     when(pendingTransaction.getTransaction()).thenReturn(transaction);
     when(transaction.encoded()).thenReturn(randomEncodedBytes);
-
-    jsonRpcManager = new JsonRpcManager(tempDataDir, URI.create(wmInfo.getHttpBaseUrl()));
+    final LineaRejectedTxReportingConfiguration config =
+        LineaRejectedTxReportingConfiguration.builder()
+            .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()))
+            .lineaNodeType(LineaNodeType.SEQUENCER)
+            .build();
+    jsonRpcManager = new JsonRpcManager(tempDataDir, config);
     jsonRpcManager.start();
   }
 

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
@@ -107,7 +107,7 @@ class JsonRpcManagerTest {
             result.maybeInvalidReason().orElse(""),
             List.of());
 
-    jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
+    jsonRpcManager.submitNewJsonRpcCallAsync(jsonRpcCall);
 
     // Use Awaitility to wait for the condition to be met
     await()
@@ -159,7 +159,7 @@ class JsonRpcManagerTest {
             List.of());
 
     // Submit the call, the scheduler will retry the failed call
-    jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
+    jsonRpcManager.submitNewJsonRpcCallAsync(jsonRpcCall);
 
     // Use Awaitility to wait for the condition to be met
     await()
@@ -207,7 +207,7 @@ class JsonRpcManagerTest {
             List.of());
 
     // Submit the call
-    jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
+    jsonRpcManager.submitNewJsonRpcCallAsync(jsonRpcCall);
 
     // Use Awaitility to wait for the condition to be met
     await()
@@ -274,7 +274,7 @@ class JsonRpcManagerTest {
             List.of());
 
     // Submit the call, the scheduler will retry the failed calls
-    jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
+    jsonRpcManager.submitNewJsonRpcCallAsync(jsonRpcCall);
 
     // Use Awaitility to wait for the condition to be met
     await()

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -101,7 +102,8 @@ class JsonRpcManagerTest {
             transaction,
             timestamp,
             Optional.of(1L),
-            result.maybeInvalidReason().orElse(""));
+            result.maybeInvalidReason().orElse(""),
+            List.of());
 
     jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
 
@@ -151,7 +153,8 @@ class JsonRpcManagerTest {
             transaction,
             timestamp,
             Optional.of(1L),
-            result.maybeInvalidReason().orElse(""));
+            result.maybeInvalidReason().orElse(""),
+            List.of());
 
     // Submit the call, the scheduler will retry the failed call
     jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
@@ -197,7 +200,8 @@ class JsonRpcManagerTest {
             transaction,
             timestamp,
             Optional.of(1L),
-            result.maybeInvalidReason().orElse(""));
+            result.maybeInvalidReason().orElse(""),
+            List.of());
 
     // Submit the call
     jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);
@@ -262,7 +266,8 @@ class JsonRpcManagerTest {
             transaction,
             timestamp,
             Optional.of(1L),
-            result.maybeInvalidReason().orElse(""));
+            result.maybeInvalidReason().orElse(""),
+            List.of());
 
     // Submit the call, the scheduler will retry the failed calls
     jsonRpcManager.submitNewJsonRpcCall(jsonRpcCall);

--- a/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
@@ -29,6 +29,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -63,12 +64,12 @@ class JsonRpcManagerTest {
   @Mock private Transaction transaction;
 
   @BeforeEach
-  void init(final WireMockRuntimeInfo wmInfo) {
+  void init(final WireMockRuntimeInfo wmInfo) throws MalformedURLException {
     // mock stubbing
     when(transaction.encoded()).thenReturn(randomEncodedBytes);
     final LineaRejectedTxReportingConfiguration config =
         LineaRejectedTxReportingConfiguration.builder()
-            .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()))
+            .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()).toURL())
             .lineaNodeType(LineaNodeType.SEQUENCER)
             .build();
     jsonRpcManager = new JsonRpcManager(tempDataDir, config);

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/AllowedAddressValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/AllowedAddressValidatorTest.java
@@ -40,7 +40,7 @@ public class AllowedAddressValidatorTest {
   @BeforeEach
   public void initialize() {
     Set<Address> denied = Set.of(DENIED);
-    allowedAddressValidator = new AllowedAddressValidator(denied);
+    allowedAddressValidator = new AllowedAddressValidator(denied, Optional.empty());
   }
 
   @Test

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidatorTest.java
@@ -38,7 +38,8 @@ public class CalldataValidatorTest {
         new CalldataValidator(
             LineaTransactionPoolValidatorCliOptions.create().toDomainObject().toBuilder()
                 .maxTxCalldataSize(MAX_TX_CALLDATA_SIZE)
-                .build());
+                .build(),
+            Optional.empty());
   }
 
   @Test

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
@@ -38,7 +38,8 @@ public class GasLimitValidatorTest {
         new GasLimitValidator(
             LineaTransactionPoolValidatorCliOptions.create().toDomainObject().toBuilder()
                 .maxTxGasLimit(MAX_TX_GAS_LIMIT)
-                .build());
+                .build(),
+            Optional.empty());
   }
 
   @Test

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidatorTest.java
@@ -87,7 +87,8 @@ public class ProfitabilityValidatorTest {
             profitabilityConfBuilder
                 .txPoolCheckP2pEnabled(true)
                 .txPoolCheckApiEnabled(true)
-                .build());
+                .build(),
+            Optional.empty());
 
     profitabilityValidatorNever =
         new ProfitabilityValidator(
@@ -96,7 +97,8 @@ public class ProfitabilityValidatorTest {
             profitabilityConfBuilder
                 .txPoolCheckP2pEnabled(false)
                 .txPoolCheckApiEnabled(false)
-                .build());
+                .build(),
+            Optional.empty());
 
     profitabilityValidatorOnlyApi =
         new ProfitabilityValidator(
@@ -105,7 +107,8 @@ public class ProfitabilityValidatorTest {
             profitabilityConfBuilder
                 .txPoolCheckP2pEnabled(false)
                 .txPoolCheckApiEnabled(true)
-                .build());
+                .build(),
+            Optional.empty());
 
     profitabilityValidatorOnlyP2p =
         new ProfitabilityValidator(
@@ -114,7 +117,8 @@ public class ProfitabilityValidatorTest {
             profitabilityConfBuilder
                 .txPoolCheckP2pEnabled(true)
                 .txPoolCheckApiEnabled(false)
-                .build());
+                .build(),
+            Optional.empty());
   }
 
   @Test

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -121,7 +122,7 @@ public class SimulationValidatorTest {
   }
 
   @BeforeEach
-  public void initialize(final WireMockRuntimeInfo wmInfo) {
+  public void initialize(final WireMockRuntimeInfo wmInfo) throws MalformedURLException {
     final var tracerConf =
         LineaTracerConfiguration.builder()
             .moduleLimitsFilePath(lineLimitsConfPath.toString())
@@ -133,7 +134,7 @@ public class SimulationValidatorTest {
 
     final var rejectedTxReportingConf =
         LineaRejectedTxReportingConfiguration.builder()
-            .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()))
+            .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()).toURL())
             .lineaNodeType(LineaNodeType.P2P)
             .build();
     jsonRpcManager = new JsonRpcManager(tempDataDir, rejectedTxReportingConf).start();

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
@@ -137,7 +137,8 @@ public class SimulationValidatorTest {
             .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()).toURL())
             .lineaNodeType(LineaNodeType.P2P)
             .build();
-    jsonRpcManager = new JsonRpcManager(tempDataDir, rejectedTxReportingConf).start();
+    jsonRpcManager =
+        new JsonRpcManager("simulation-test", tempDataDir, rejectedTxReportingConf).start();
 
     // rejected tx json-rpc stubbing
     stubFor(

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
@@ -127,7 +127,8 @@ public class SimulationValidatorTest {
         LineaL1L2BridgeSharedConfiguration.builder()
             .contract(BRIDGE_CONTRACT)
             .topic(BRIDGE_LOG_TOPIC)
-            .build());
+            .build(),
+        Optional.empty());
   }
 
   @Test

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/SimulationValidatorTest.java
@@ -15,22 +15,39 @@
 
 package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.config.LineaNodeType;
+import net.consensys.linea.config.LineaRejectedTxReportingConfiguration;
 import net.consensys.linea.config.LineaTracerConfiguration;
 import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
+import net.consensys.linea.jsonrpc.JsonRpcManager;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
 import net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator;
 import net.consensys.linea.sequencer.txselection.selectors.TraceLineLimitTransactionSelectorTest;
@@ -44,6 +61,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.TransactionSimulationService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +72,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @Slf4j
 @RequiredArgsConstructor
+@WireMockTest
 @ExtendWith(MockitoExtension.class)
 public class SimulationValidatorTest {
   private static final String MODULE_LINE_LIMITS_RESOURCE_NAME = "/sequencer/line-limits.toml";
@@ -87,7 +106,8 @@ public class SimulationValidatorTest {
 
   @Mock BlockchainService blockchainService;
   @Mock TransactionSimulationService transactionSimulationService;
-
+  private JsonRpcManager jsonRpcManager;
+  @TempDir private Path tempDataDir;
   @TempDir static Path tempDir;
   static Path lineLimitsConfPath;
 
@@ -101,7 +121,7 @@ public class SimulationValidatorTest {
   }
 
   @BeforeEach
-  public void initialize() {
+  public void initialize(final WireMockRuntimeInfo wmInfo) {
     final var tracerConf =
         LineaTracerConfiguration.builder()
             .moduleLimitsFilePath(lineLimitsConfPath.toString())
@@ -110,6 +130,28 @@ public class SimulationValidatorTest {
     final var blockHeader = mock(BlockHeader.class);
     when(blockHeader.getBaseFee()).thenReturn(Optional.of(BASE_FEE));
     when(blockchainService.getChainHeadHeader()).thenReturn(blockHeader);
+
+    final var rejectedTxReportingConf =
+        LineaRejectedTxReportingConfiguration.builder()
+            .rejectedTxEndpoint(URI.create(wmInfo.getHttpBaseUrl()))
+            .lineaNodeType(LineaNodeType.P2P)
+            .build();
+    jsonRpcManager = new JsonRpcManager(tempDataDir, rejectedTxReportingConf).start();
+
+    // rejected tx json-rpc stubbing
+    stubFor(
+        post(urlEqualTo("/"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"jsonrpc\":\"2.0\",\"result\":{ \"status\": \"SAVED\"},\"id\":1}")));
+  }
+
+  @AfterEach
+  void cleanup() {
+    jsonRpcManager.shutdown();
   }
 
   private SimulationValidator createSimulationValidator(
@@ -128,7 +170,7 @@ public class SimulationValidatorTest {
             .contract(BRIDGE_CONTRACT)
             .topic(BRIDGE_LOG_TOPIC)
             .build(),
-        Optional.empty());
+        Optional.of(jsonRpcManager));
   }
 
   @Test
@@ -148,7 +190,7 @@ public class SimulationValidatorTest {
   }
 
   @Test
-  public void moduleLineCountOverflowTransactionIsInvalid() {
+  public void moduleLineCountOverflowTransactionIsInvalidAndReported() {
     lineCountLimits.put("EXT", 5);
     final var simulationValidator = createSimulationValidator(lineCountLimits, true, false);
     final org.hyperledger.besu.ethereum.core.Transaction transaction =
@@ -161,8 +203,25 @@ public class SimulationValidatorTest {
             .value(Wei.ONE)
             .signature(FAKE_SIGNATURE)
             .build();
+    final var expectedReasonMessage =
+        "Transaction 0xbf668c5dc926c008d5b34f347e1842b94911b46f4a36b668812f821e20303322 line count for module EXT=7 is above the limit 5";
     assertThat(simulationValidator.validateTransaction(transaction, true, false))
-        .contains(
-            "Transaction 0xbf668c5dc926c008d5b34f347e1842b94911b46f4a36b668812f821e20303322 line count for module EXT=7 is above the limit 5");
+        .contains(expectedReasonMessage);
+
+    // assert that wiremock received 1 post request for rejected tx.
+    // Use Awaitility to wait for the condition to be met
+    await()
+        .atMost(6, SECONDS)
+        .untilAsserted(
+            () ->
+                verify(
+                    exactly(1),
+                    postRequestedFor(urlEqualTo("/"))
+                        .withRequestBody(
+                            matchingJsonPath(
+                                "$.params.txRejectionStage", equalTo(LineaNodeType.P2P.name())))
+                        .withRequestBody(
+                            matchingJsonPath(
+                                "$.params.reasonMessage", equalTo(expectedReasonMessage)))));
   }
 }


### PR DESCRIPTION
feat: Report rejected transactions to an external service for tx pool validators used by LineaTransactionPoolValidatorPlugin

Introduced/updated following cli options (`LineaRejectedTxReportingCliOptions`):
`--plugin-linea-rejected-tx-endpoint` - Endpoint URI for reporting rejected transactions. Specify a valid URI to enable reporting.
`--plugin-linea-node-type` - Linea Node type to use when reporting rejected transactions. (default: SEQUENCER. Valid values: SEQUENCER,P2P,RPC)
