### PR TITLE
`linea_estimateGas`: calculate the gas limit the sender according to his balance

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaEstimateGasEndpointPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaEstimateGasEndpointPlugin.java
@@ -78,7 +78,8 @@ public class LineaEstimateGasEndpointPlugin extends AbstractLineaRequiredPlugin 
                         "Failed to obtain BlockchainService from the BesuContext."));
 
     lineaEstimateGasMethod =
-        new LineaEstimateGas(besuConfiguration, transactionSimulationService, blockchainService);
+        new LineaEstimateGas(
+            besuConfiguration, transactionSimulationService, blockchainService, rpcEndpointService);
 
     rpcEndpointService.registerRPCEndpoint(
         lineaEstimateGasMethod.getNamespace(),


### PR DESCRIPTION
`linea_estimateGas` now takes in consideration the balance of the sender to set the `gasLimit` for the first estimation, to avoid that setting the `gasLimit` to the max allowed by the configuration, could result in failures with _not enough balance_ to pay for gas, so capping the `gasLimit` to what the sender can afford to pay, prevents this issue.

For `linea_estimateGas` to work, the in-process RPC must be enabled and `ETH` methods exposed, since the plugin need to be able to call `eth_getBalance`:
1. `Xin-process-rpc-enabled=true`
2. `Xin-process-rpc-apis=["ETH"]`

I also took the opportunity to fix the `logId` used to correlate log lines for a specific request.