### PR TITLE
Fix a config key name clash with the tracer

### DIFF
--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/TestCommandLineOptionsBuilder.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/TestCommandLineOptionsBuilder.java
@@ -41,6 +41,7 @@ public class TestCommandLineOptionsBuilder {
         "--plugin-linea-l1l2-bridge-contract=", "0x00000000000000000000000000000000DEADBEEF");
     cliOptions.setProperty("--plugin-linea-l1l2-bridge-topic=", "0x123456");
     cliOptions.setProperty("--plugin-linea-conflated-trace-generation-traces-output-path=", ".");
+    cliOptions.setProperty("--plugin-linea-rpc-concurrent-requests-limit=", "1");
   }
 
   public TestCommandLineOptionsBuilder set(String option, String value) {

--- a/sequencer/src/main/java/net/consensys/linea/config/LineaRpcCliOptions.java
+++ b/sequencer/src/main/java/net/consensys/linea/config/LineaRpcCliOptions.java
@@ -23,7 +23,7 @@ import picocli.CommandLine;
 
 /** The Linea RPC CLI options. */
 public class LineaRpcCliOptions implements LineaCliOptions {
-  public static final String CONFIG_KEY = "rpc-config";
+  public static final String CONFIG_KEY = "rpc-config-sequencer";
 
   private static final String ESTIMATE_GAS_COMPATIBILITY_MODE_ENABLED =
       "--plugin-linea-estimate-gas-compatibility-mode-enabled";


### PR DESCRIPTION
The tracer recently added the `rpc-config` config key, since the sequencer already there was an issue when using both plugins

```
2024-09-26 18:11:41.816+0200 | Test worker | ERROR | o.h.b.s.BesuPluginContextImpl | Error calling `beforeExternalServices` on plugin of type net.consensys.linea.plugins.rpc.linecounts.LineCountsEndpointServicePlugin, stop will not be called.
java.lang.ClassCastException: class net.consensys.linea.config.LineaRpcConfiguration cannot be cast to class net.consensys.linea.plugins.rpc.RpcConfiguration (net.consensys.linea.config.LineaRpcConfiguration and net.consensys.linea.plugins.rpc.RpcConfiguration are in unnamed module of loader 'app')
	at net.consensys.linea.plugins.AbstractLineaSharedOptionsPlugin.rpcConfiguration(AbstractLineaSharedOptionsPlugin.java:47)
	at net.consensys.linea.plugins.rpc.linecounts.LineCountsEndpointServicePlugin.beforeExternalServices(LineCountsEndpointServicePlugin.java:57)
	at org.hyperledger.besu.services.BesuPluginContextImpl.beforeExternalServices(BesuPluginContextImpl.java:222)
```	