### PR TITLE
log plugin name at registration; remove override of getName() method

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/AbstractLineaRequiredPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/AbstractLineaRequiredPlugin.java
@@ -36,7 +36,10 @@ public abstract class AbstractLineaRequiredPlugin extends AbstractLineaPrivateOp
   public void register(final BesuContext context) {
     super.register(context);
     try {
-      log.info("Registering Linea plugin {}", this.getClass().getName());
+      log.info(
+          "Registering Linea plugin of type {} with name {}",
+          this.getClass().getName(),
+          this.getName());
 
       blockchainService =
           context

--- a/sequencer/src/main/java/net/consensys/linea/AbstractLineaRequiredPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/AbstractLineaRequiredPlugin.java
@@ -34,10 +34,7 @@ public abstract class AbstractLineaRequiredPlugin extends AbstractLineaSharedPri
   public void register(final BesuContext context) {
     super.register(context);
     try {
-      log.info(
-          "Registering Linea plugin of type {} with name {}",
-          this.getClass().getName(),
-          this.getName());
+      log.info("Registering Linea plugin {}", this.getClass().getName());
 
       doRegister(context);
 

--- a/sequencer/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.extradata;
 
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.auto.service.AutoService;

--- a/sequencer/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/extradata/LineaExtraDataPlugin.java
@@ -15,8 +15,6 @@
 
 package net.consensys.linea.extradata;
 
-import java.util.Optional;
-
 import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.AbstractLineaRequiredPlugin;
@@ -29,14 +27,8 @@ import org.hyperledger.besu.plugin.services.RpcEndpointService;
 @Slf4j
 @AutoService(BesuPlugin.class)
 public class LineaExtraDataPlugin extends AbstractLineaRequiredPlugin {
-  public static final String NAME = "linea";
   private BesuContext besuContext;
   private RpcEndpointService rpcEndpointService;
-
-  @Override
-  public Optional<String> getName() {
-    return Optional.of(NAME);
-  }
 
   @Override
   public void doRegister(final BesuContext context) {

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
@@ -46,16 +46,10 @@ import org.hyperledger.besu.plugin.services.TransactionSimulationService;
 @Slf4j
 @AutoService(BesuPlugin.class)
 public class LineaTransactionPoolValidatorPlugin extends AbstractLineaRequiredPlugin {
-  public static final String NAME = "linea";
   private BesuConfiguration besuConfiguration;
   private TransactionPoolValidatorService transactionPoolValidatorService;
   private TransactionSimulationService transactionSimulationService;
   private Optional<JsonRpcManager> rejectedTxJsonRpcManager = Optional.empty();
-
-  @Override
-  public Optional<String> getName() {
-    return Optional.of(NAME);
-  }
 
   @Override
   public void doRegister(final BesuContext context) {

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
@@ -38,15 +38,9 @@ import org.hyperledger.besu.plugin.services.TransactionSelectionService;
 @Slf4j
 @AutoService(BesuPlugin.class)
 public class LineaTransactionSelectorPlugin extends AbstractLineaRequiredPlugin {
-  public static final String NAME = "linea";
   private TransactionSelectionService transactionSelectionService;
   private Optional<JsonRpcManager> rejectedTxJsonRpcManager = Optional.empty();
   private BesuConfiguration besuConfiguration;
-
-  @Override
-  public Optional<String> getName() {
-    return Optional.of(NAME);
-  }
 
   @Override
   public void doRegister(final BesuContext context) {


### PR DESCRIPTION
unique plugin names are required for identification purposes. These plugins were all named "linea" which made it impossible to differentiate between them using name.

when calling `plugins_reloadPluginConfig` the name specified must match the getName() value so it must be unique for this function to be available. 