### PR TITLE
Workaround for overwritten Tracer MANIFEST.MF

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion=0.8.0-rc8.1
+releaseVersion=0.8.0-rc8.2
 besuVersion=24.12-delivery40
 arithmetizationVersion=0.8.0-rc8
 besuArtifactGroup=io.consensys.linea-besu

--- a/gradle/dist.gradle
+++ b/gradle/dist.gradle
@@ -32,10 +32,10 @@ jar {
 
   manifest {
     attributes(
-      'Specification-Title': archiveBaseName.get(),
-      'Specification-Version': rootProject.version,
-      'Implementation-Title': archiveBaseName.get(),
-      'Implementation-Version': calculateVersion()
+      'Specification-Title': 'arithmetization',
+      'Specification-Version': arithmetizationVersion,
+      'Implementation-Title': 'arithmetization',
+      'Implementation-Version': arithmetizationVersion
     )
   }
 


### PR DESCRIPTION
When building the uber jar, the `MANIFEST.MF` from the Tracer is overwritten with Sequencer data, but since the Sequencer does not use it at runtime, while it is necessary for the Tracer, we just recreate it as the Tracer expect it