### PR TITLE
Workaround for overwritten Tracer MANIFEST.MF (part 2)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion=0.8.0-rc8.1
+releaseVersion=0.8.0-rc8.3
 besuVersion=24.12-delivery40
 arithmetizationVersion=0.8.0-rc8
 besuArtifactGroup=io.consensys.linea-besu

--- a/gradle/dist.gradle
+++ b/gradle/dist.gradle
@@ -32,10 +32,10 @@ jar {
 
   manifest {
     attributes(
-      'Specification-Title': archiveBaseName.get(),
-      'Specification-Version': rootProject.version,
-      'Implementation-Title': archiveBaseName.get(),
-      'Implementation-Version': calculateVersion()
+      'Specification-Title': 'arithmetization',
+      'Specification-Version': "v${arithmetizationVersion}",
+      'Implementation-Title': 'arithmetization',
+      'Implementation-Version': "v${arithmetizationVersion}"
     )
   }
 


### PR DESCRIPTION
add the missing `v` prefix