### PR TITLE
log4j: replace status (deprecated) with level

### DIFF
--- a/acceptance-tests/src/test/resources/log4j2.xml
+++ b/acceptance-tests/src/test/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
     <Properties>
         <Property name="root.log.level">TRACE</Property>
     </Properties>


### PR DESCRIPTION
The attribute status has been deprecated in log4j since log4j version 2.24.0. Reference: https://logging.apache.org/log4j/2.x/manual/configuration.html#configuration-attribute-status

For reference, Besu repo changes https://github.com/hyperledger/besu/pull/8087