### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Release Dist Asset
-        id: upload-release-asset
+        id: upload-release-dist-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix:

 Invalid workflow file: .github/workflows/release.yml#L90
The workflow is not valid. .github/workflows/release.yml (Line: 90, Col: 13): The identifier 'upload-release-asset' may not be used more than once within the same scope.
