### PR TITLE
Log extra data parsing at debug

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
+++ b/sequencer/src/main/java/net/consensys/linea/extradata/LineaExtraDataHandler.java
@@ -126,7 +126,7 @@ public class LineaExtraDataHandler {
     }
 
     public synchronized void accept(final Bytes extraData) {
-      log.info("Parsing extra data version 1: {}", extraData.toHexString());
+      log.debug("Parsing extra data version 1: {}", extraData.toHexString());
       int startIndex = 0;
       for (final FieldConsumer fieldConsumer : fieldsSequence) {
         fieldConsumer.accept(extraData.slice(startIndex, fieldConsumer.length));


### PR DESCRIPTION
Extra data parsing is now logged at INFO for each imported block and it is quite noisy, so better to log it a DEBUG

```
2025-02-14 16:36:59.967+00:00 | EthScheduler-Workers-0 | INFO  | LineaExtraDataHandler | Parsing extra data version 1: 0x0000753000da50f500030e88000000000000000000000000000000000000003d0f69ad0b6a87e7dac792ce5672c49d2d9b377be9a412e1da76a77f63876cee62c7e3d73db5118c0123fcd0c12874b27e056e5b633b78b63a2d1e426a78917c01
```