### PR TITLE
Add check to detect and report invalid line counts

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/sequencer/modulelimit/ModuleLimitsValidationResult.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/modulelimit/ModuleLimitsValidationResult.java
@@ -57,6 +57,17 @@ public class ModuleLimitsValidationResult {
         null);
   }
 
+  public static ModuleLimitsValidationResult invalidLineCount(
+      final String moduleName, final Integer moduleLineCount) {
+    return new ModuleLimitsValidationResult(
+        ModuleLineCountValidator.ModuleLineCountResult.INVALID_LINE_COUNT,
+        moduleName,
+        moduleLineCount,
+        null,
+        null,
+        null);
+  }
+
   public static ModuleLimitsValidationResult txModuleLineCountOverflow(
       final String moduleName,
       final Integer moduleLineCount,

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/modulelimit/ModuleLineCountValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/modulelimit/ModuleLineCountValidator.java
@@ -70,9 +70,17 @@ public class ModuleLineCountValidator {
       final Map<String, Integer> currentAccumulatedLineCounts,
       final Map<String, Integer> prevAccumulatedLineCounts) {
     for (Map.Entry<String, Integer> moduleEntry : currentAccumulatedLineCounts.entrySet()) {
-      String moduleName = moduleEntry.getKey();
-      Integer currentTotalLineCountForModule = moduleEntry.getValue();
-      Integer lineCountLimitForModule = moduleLineCountLimits.get(moduleName);
+      final String moduleName = moduleEntry.getKey();
+      final int currentTotalLineCountForModule = moduleEntry.getValue();
+      if (currentTotalLineCountForModule < 0) {
+        log.error(
+            "Negative line count {} returned for module '{}'.",
+            currentAccumulatedLineCounts,
+            moduleName);
+        return ModuleLimitsValidationResult.invalidLineCount(
+            moduleName, currentTotalLineCountForModule);
+      }
+      final Integer lineCountLimitForModule = moduleLineCountLimits.get(moduleName);
 
       if (lineCountLimitForModule == null) {
         log.error("Module '{}' is not defined in the line count limits.", moduleName);
@@ -113,7 +121,8 @@ public class ModuleLineCountValidator {
     VALID,
     TX_MODULE_LINE_COUNT_OVERFLOW,
     BLOCK_MODULE_LINE_COUNT_FULL,
-    MODULE_NOT_DEFINED
+    MODULE_NOT_DEFINED,
+    INVALID_LINE_COUNT
   }
 
   public static Map<String, Integer> createLimitModules(

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectionResult.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectionResult.java
@@ -24,6 +24,7 @@ public class LineaTransactionSelectionResult extends TransactionSelectionResult 
     TX_TOO_LARGE_FOR_REMAINING_USER_GAS(false, false, false),
     TX_MODULE_LINE_COUNT_OVERFLOW(false, true, true),
     TX_MODULE_LINE_COUNT_OVERFLOW_CACHED(false, true, true),
+    TX_MODULE_LINE_INVALID_COUNT(false, true, true),
     TX_UNPROFITABLE(false, false, true),
     TX_UNPROFITABLE_UPFRONT(false, false, true),
     TX_UNPROFITABLE_RETRY_LIMIT(false, false, false),
@@ -71,6 +72,8 @@ public class LineaTransactionSelectionResult extends TransactionSelectionResult 
       new LineaTransactionSelectionResult(LineaStatus.TX_MODULE_LINE_COUNT_OVERFLOW);
   public static final TransactionSelectionResult TX_MODULE_LINE_COUNT_OVERFLOW_CACHED =
       new LineaTransactionSelectionResult(LineaStatus.TX_MODULE_LINE_COUNT_OVERFLOW_CACHED);
+  public static final TransactionSelectionResult TX_MODULE_LINE_INVALID_COUNT =
+      new LineaTransactionSelectionResult(LineaStatus.TX_MODULE_LINE_INVALID_COUNT);
   public static final TransactionSelectionResult TX_UNPROFITABLE =
       new LineaTransactionSelectionResult(LineaStatus.TX_UNPROFITABLE);
   public static final TransactionSelectionResult TX_UNPROFITABLE_UPFRONT =

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/TraceLineLimitTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/TraceLineLimitTransactionSelector.java
@@ -17,6 +17,7 @@ package net.consensys.linea.sequencer.txselection.selectors;
 import static net.consensys.linea.sequencer.txselection.LineaTransactionSelectionResult.BLOCK_MODULE_LINE_COUNT_FULL;
 import static net.consensys.linea.sequencer.txselection.LineaTransactionSelectionResult.TX_MODULE_LINE_COUNT_OVERFLOW;
 import static net.consensys.linea.sequencer.txselection.LineaTransactionSelectionResult.TX_MODULE_LINE_COUNT_OVERFLOW_CACHED;
+import static net.consensys.linea.sequencer.txselection.LineaTransactionSelectionResult.TX_MODULE_LINE_INVALID_COUNT;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTED;
 
 import java.math.BigInteger;
@@ -151,6 +152,13 @@ public class TraceLineLimitTransactionSelector
         log.error("Module {} does not exist in the limits file.", result.getModuleName());
         throw new RuntimeException(
             "Module " + result.getModuleName() + " does not exist in the limits file.");
+      case INVALID_LINE_COUNT:
+        log.warn(
+            "Tx {} line count for module {}={} is invalid, removing from the txpool",
+            transaction.getHash(),
+            result.getModuleName(),
+            result.getModuleLineCount());
+        return TX_MODULE_LINE_INVALID_COUNT;
       case TX_MODULE_LINE_COUNT_OVERFLOW:
         log.warn(
             "Tx {} line count for module {}={} is above the limit {}, removing from the txpool",

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/modulelimit/ModuleLineCountValidatorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/modulelimit/ModuleLineCountValidatorTest.java
@@ -64,4 +64,15 @@ class ModuleLineCountValidatorTest {
     assertThat(moduleLineCountValidator.validate(lineCountTx, lineCountTx))
         .isEqualTo(ModuleLimitsValidationResult.moduleNotDefined("MOD4"));
   }
+
+  @Test
+  void failedValidationInvalidLineCount() {
+    final var moduleLineCountValidator =
+        new ModuleLineCountValidator(Map.of("MOD1", 1, "MOD2", 2, "MOD3", 3));
+
+    final var lineCountTx = Map.of("MOD1", 1, "MOD2", -2, "MOD3", 1);
+
+    assertThat(moduleLineCountValidator.validate(lineCountTx, lineCountTx))
+        .isEqualTo(ModuleLimitsValidationResult.invalidLineCount("MOD2", -2));
+  }
 }


### PR DESCRIPTION
Module line counts returned by the ZkTracer must be >= 0, so we add an extra check to validate this constraint.