### PR TITLE
Save and restore bundle pool

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/AbstractLineaSharedPrivateOptionsPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/AbstractLineaSharedPrivateOptionsPlugin.java
@@ -214,7 +214,10 @@ public abstract class AbstractLineaSharedPrivateOptionsPlugin
 
     bundlePoolService =
         new LineaLimitedBundlePool(
-            transactionSelectorConfiguration().maxBundlePoolSizeBytes(), besuEvents);
+            besuConfiguration.getDataPath(),
+            transactionSelectorConfiguration().maxBundlePoolSizeBytes(),
+            besuEvents);
+    bundlePoolService.loadFromDisk();
   }
 
   @Override

--- a/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaLimitedBundlePool.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaLimitedBundlePool.java
@@ -15,8 +15,15 @@
 
 package net.consensys.linea.rpc.services;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -44,8 +51,10 @@ import org.hyperledger.besu.plugin.services.BesuService;
 @AutoService(BesuService.class)
 @Slf4j
 public class LineaLimitedBundlePool implements BundlePoolService, BesuEvents.BlockAddedListener {
+  public static final String BUNDLE_SAVE_FILENAME = "bundles.dump";
   private final Cache<Hash, TransactionBundle> cache;
   private final Map<Long, List<TransactionBundle>> blockIndex;
+  private final Path saveFilePath;
   private final AtomicLong maxBlockHeight = new AtomicLong(0L);
 
   /**
@@ -55,7 +64,9 @@ public class LineaLimitedBundlePool implements BundlePoolService, BesuEvents.Blo
    * @param maxSizeInBytes The maximum size in bytes of the pool objects.
    */
   @VisibleForTesting
-  public LineaLimitedBundlePool(long maxSizeInBytes, BesuEvents eventService) {
+  public LineaLimitedBundlePool(
+      final Path dataDir, final long maxSizeInBytes, final BesuEvents eventService) {
+    this.saveFilePath = dataDir.resolve(BUNDLE_SAVE_FILENAME);
     this.cache =
         Caffeine.newBuilder()
             .maximumWeight(maxSizeInBytes) // Maximum size in bytes
@@ -183,6 +194,63 @@ public class LineaLimitedBundlePool implements BundlePoolService, BesuEvents.Blo
   @Override
   public long size() {
     return cache.estimatedSize();
+  }
+
+  @Override
+  public void saveToDisk() {
+    log.info("Saving bundles to {}", saveFilePath);
+    try (final BufferedWriter bw =
+        Files.newBufferedWriter(saveFilePath, StandardCharsets.US_ASCII)) {
+      final var savedCount =
+          blockIndex.values().stream()
+              .flatMap(List::stream)
+              .sorted(Comparator.comparing(TransactionBundle::blockNumber))
+              .map(TransactionBundle::serializeForDisk)
+              .peek(
+                  str -> {
+                    try {
+                      bw.write(str);
+                      bw.newLine();
+                    } catch (IOException e) {
+                      throw new RuntimeException(e);
+                    }
+                  })
+              .count();
+      log.info("Saved {} bundles to {}", savedCount, saveFilePath);
+    } catch (final Throwable ioe) {
+      log.error("Error while saving bundles to {}", saveFilePath, ioe);
+    }
+  }
+
+  @Override
+  public void loadFromDisk() {
+    if (saveFilePath.toFile().exists()) {
+      log.info("Loading bundles from {}", saveFilePath);
+      final var loadedCount = new AtomicLong(0L);
+      try (final BufferedReader br =
+          Files.newBufferedReader(saveFilePath, StandardCharsets.US_ASCII)) {
+        br.lines()
+            .parallel()
+            .forEach(
+                line -> {
+                  try {
+                    final var bundle = TransactionBundle.restoreFromSerialized(line);
+                    this.putOrReplace(bundle.bundleIdentifier(), bundle);
+                    loadedCount.incrementAndGet();
+                  } catch (final Exception e) {
+                    log.warn("Error while loading bundle from serialized format {}", line, e);
+                  }
+                });
+        log.info("Loaded {} bundles from {}", loadedCount.get(), saveFilePath);
+      } catch (final Throwable t) {
+        log.error(
+            "Error while reading bundles from {}, partially loaded {} bundles",
+            saveFilePath,
+            loadedCount.get(),
+            t);
+      }
+      saveFilePath.toFile().delete();
+    }
   }
 
   /**

--- a/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaSendBundleEndpointPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaSendBundleEndpointPlugin.java
@@ -60,4 +60,10 @@ public class LineaSendBundleEndpointPlugin extends AbstractLineaRequiredPlugin {
     lineaSendBundleMethod.init(bundlePoolService);
     lineaCancelBundleMethod.init(bundlePoolService);
   }
+
+  @Override
+  public void stop() {
+
+    super.stop();
+  }
 }

--- a/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendBundleTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendBundleTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,9 +38,10 @@ import org.hyperledger.besu.plugin.services.BesuEvents;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class LineaSendBundleTest {
-
+  @TempDir Path dataDir;
   private LineaSendBundle lineaSendBundle;
   private BesuEvents mockEvents;
   private LineaLimitedBundlePool bundlePool;
@@ -59,7 +61,7 @@ class LineaSendBundleTest {
   @BeforeEach
   void setup() {
     mockEvents = mock(BesuEvents.class);
-    bundlePool = spy(new LineaLimitedBundlePool(4096L, mockEvents));
+    bundlePool = spy(new LineaLimitedBundlePool(dataDir, 4096L, mockEvents));
     lineaSendBundle = new LineaSendBundle().init(bundlePool);
   }
 

--- a/sequencer/src/test/java/net/consensys/linea/rpc/services/TransactionBundleTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/rpc/services/TransactionBundleTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.rpc.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import net.consensys.linea.rpc.services.BundlePoolService.TransactionBundle;
+import org.hyperledger.besu.crypto.KeyPair;
+import org.hyperledger.besu.crypto.SECPPrivateKey;
+import org.hyperledger.besu.crypto.SECPPublicKey;
+import org.hyperledger.besu.crypto.SignatureAlgorithm;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+import org.junit.jupiter.api.Test;
+
+class TransactionBundleTest {
+  private static final KeyPair KEY_PAIR_1 =
+      new KeyPair(
+          SECPPrivateKey.create(BigInteger.valueOf(Long.MAX_VALUE), SignatureAlgorithm.ALGORITHM),
+          SECPPublicKey.create(BigInteger.valueOf(Long.MIN_VALUE), SignatureAlgorithm.ALGORITHM));
+
+  private static final Transaction TX1 =
+      new TransactionTestFixture().nonce(0).gasLimit(21000).createTransaction(KEY_PAIR_1);
+  private static final Transaction TX2 =
+      new TransactionTestFixture().nonce(1).gasLimit(21000).createTransaction(KEY_PAIR_1);
+  private static final Transaction TX3 =
+      new TransactionTestFixture().nonce(2).gasLimit(21000).createTransaction(KEY_PAIR_1);
+
+  @Test
+  void serializeForDisk() {
+
+    Hash hash1 = Hash.fromHexStringLenient("0x1234");
+    TransactionBundle bundle1 = createBundle(hash1, 1, List.of(TX1, TX2));
+
+    assertThat(bundle1.serializeForDisk())
+        .isEqualTo(
+            "1|1|0x0000000000000000000000000000000000000000000000000000000000001234||||+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7,+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf$");
+  }
+
+  @Test
+  void restoreFromSerialized() {
+    TransactionBundle bundle =
+        TransactionBundle.restoreFromSerialized(
+            "1|1|0x0000000000000000000000000000000000000000000000000000000000001234||||+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7,+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf$");
+
+    assertThat(bundle.blockNumber()).isEqualTo(1);
+    assertThat(bundle.bundleIdentifier()).isEqualTo(Hash.fromHexStringLenient("0x1234"));
+    assertThat(bundle.pendingTransactions())
+        .map(PendingTransaction::getTransaction)
+        .map(Transaction::getHash)
+        .containsExactly(TX1.getHash(), TX2.getHash());
+  }
+
+  @Test
+  void restoreFromSerializedUnsupportedVersion() {
+    assertThatThrownBy(
+            () ->
+                TransactionBundle.restoreFromSerialized(
+                    "2|1|0x0000000000000000000000000000000000000000000000000000000000001234||||+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7,+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf$"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith("Unsupported bundle serialization version 2");
+  }
+
+  @Test
+  void restoreFromSerializedMalformed() {
+    assertThatThrownBy(
+            () ->
+                TransactionBundle.restoreFromSerialized(
+                    "1|1|0x0000000000000000000000000000000000000000000000000000000000001234$"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith("Invalid bundle serialization, expected 7 fields but got 3");
+  }
+
+  @Test
+  void restoreFromSerializedParseError() {
+    assertThatThrownBy(
+            () ->
+                TransactionBundle.restoreFromSerialized(
+                    "1|should be a number|0x0000000000000000000000000000000000000000000000000000000000001234||||+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7,+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf$"))
+        .isInstanceOf(NumberFormatException.class)
+        .hasMessage("For input string: \"should be a number\"");
+  }
+
+  @Test
+  void restoreFromSerializedUnterminatedLine() {
+    assertThatThrownBy(
+            () ->
+                TransactionBundle.restoreFromSerialized(
+                    "1|should be a number|0x0000000000000000000000000000000000000000000000000000000000001234||||+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7,+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unterminated bundle serialization, missing terminal $");
+  }
+
+  private TransactionBundle createBundle(Hash hash, long blockNumber, List<Transaction> maybeTxs) {
+    return new TransactionBundle(
+        hash, maybeTxs, blockNumber, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+}

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
@@ -81,6 +81,7 @@ class LineaTransactionSelectorFactoryTest {
   private LineaTransactionSelectorFactory factory;
 
   @TempDir static Path tempDir;
+  @TempDir Path dataDir;
   static Path lineLimitsConfPath;
 
   @BeforeAll
@@ -109,7 +110,7 @@ class LineaTransactionSelectorFactoryTest {
         new LineaL1L2BridgeSharedConfiguration(BRIDGE_CONTRACT, BRIDGE_LOG_TOPIC);
     mockProfitabilityConfiguration = mock(LineaProfitabilityConfiguration.class);
     mockEvents = mock(BesuEvents.class);
-    bundlePool = spy(new LineaLimitedBundlePool(4096, mockEvents));
+    bundlePool = spy(new LineaLimitedBundlePool(dataDir, 4096, mockEvents));
 
     factory =
         new LineaTransactionSelectorFactory(


### PR DESCRIPTION
With this PR the bundle pool is saved on disk in a file, when Besu stops and when Besu starts if the save file is present then populated the bundle pool with the content of that save file.

The save file is versioned, so if in future if bundles will have more fields then we can easily bump the version to support the new format.

Fixes #160 