### PR TITLE
[MINOR] adjust log message

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/sequencer/modulelimit/ModuleLineCountValidator.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/modulelimit/ModuleLineCountValidator.java
@@ -83,7 +83,7 @@ public class ModuleLineCountValidator {
       final Integer lineCountLimitForModule = moduleLineCountLimits.get(moduleName);
 
       if (lineCountLimitForModule == null) {
-        log.error("Module '{}' is not defined in the line count limits.", moduleName);
+        log.error("Module '{}' is not defined in limits config.", moduleName);
         return ModuleLimitsValidationResult.moduleNotDefined(moduleName);
       }
 


### PR DESCRIPTION
feedback that this is confusing -

eg

2025-01-09 09:48:30.569+00:00 | nioEventLoopGroup-3-5 | ERROR | ModuleLineCountValidator | Module 'SHAKIRA_DATA' is not defined in the line count limits.