### PR TITLE
WIP - feat: Sequencer plugin to send a L2 pausing tx when sequencer hasn't produced block recently

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/sequencer/liveness/LivenessPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/liveness/LivenessPlugin.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.sequencer.liveness;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.auto.service.AutoService;
+import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.AbstractLineaRequiredPlugin;
+import net.consensys.linea.config.LineaNodeType;
+import net.consensys.linea.config.LineaRejectedTxReportingConfiguration;
+import net.consensys.linea.jsonrpc.JsonRpcManager;
+import net.consensys.linea.jsonrpc.JsonRpcRequestBuilder;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.data.AddedBlockContext;
+import org.hyperledger.besu.plugin.data.BlockHeader;
+import org.hyperledger.besu.plugin.services.BesuEvents;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+import org.web3j.abi.FunctionEncoder;
+import org.web3j.abi.datatypes.Bool;
+import org.web3j.abi.datatypes.Function;
+import org.web3j.abi.datatypes.generated.Uint256;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.RawTransaction;
+import org.web3j.crypto.TransactionEncoder;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
+import org.web3j.protocol.http.HttpService;
+import org.web3j.utils.Numeric;
+
+@Slf4j
+@AutoService(BesuPlugin.class)
+public class LivenessPlugin extends AbstractLineaRequiredPlugin
+    implements BesuEvents.BlockAddedListener {
+
+  private static final String PLUGIN_NAME = "LivenessPlugin";
+  private static final BigInteger DEFAULT_CHAIN_ID = new BigInteger("59144");
+
+  private BlockchainService blockchainService;
+  private Web3j web3j;
+  private Credentials credentials;
+
+  private ScheduledExecutorService scheduler;
+  private final AtomicReference<BlockHeader> lastProcessedBlock = new AtomicReference<>();
+  private final AtomicLong lastReportedTimestamp = new AtomicLong(0);
+  private boolean enabled = false;
+
+  // Configuration options
+  private long maxBlockAgeSeconds;
+  private Address contractAddress;
+  private long gasLimit;
+  private BigInteger chainId;
+
+  private JsonRpcManager jsonRpcManager;
+
+  private LivenessPluginCliOptions cliOptions;
+
+  @Override
+  public void doRegister(final ServiceManager serviceManager) {
+    log.info("Registering {} ...", PLUGIN_NAME);
+
+    try {
+      // Register CLI options
+      serviceManager
+          .getService(PicoCLIOptions.class)
+          .orElseThrow(() -> new RuntimeException("Failed to obtain PicoCLIOptions"))
+          .addPicoCLIOptions(
+              LivenessPluginCliOptions.CONFIG_KEY, LivenessPluginCliOptions.create());
+
+      // Get required services
+      blockchainService =
+          serviceManager
+              .getService(BlockchainService.class)
+              .orElseThrow(() -> new RuntimeException("Failed to obtain BlockchainService"));
+
+      // Register for block events if available
+      serviceManager
+          .getService(BesuEvents.class)
+          .ifPresent(events -> events.addBlockAddedListener(this));
+
+      jsonRpcManager =
+          new JsonRpcManager(
+              PLUGIN_NAME,
+              Path.of("/tmp/besu-dev"),
+              new LineaRejectedTxReportingConfiguration(
+                  URI.create("http://localhost:8545").toURL(), LineaNodeType.SEQUENCER));
+
+      log.info("{} registered successfully", PLUGIN_NAME);
+    } catch (Exception e) {
+      log.warn("{} registration failed: {}", PLUGIN_NAME, e.getMessage());
+      // Don't rethrow the exception to allow Besu to continue starting
+    }
+  }
+
+  @Override
+  public void doStart() {
+    log.info("Starting {} ...", PLUGIN_NAME);
+
+    if (cliOptions == null) {
+      cliOptions = LivenessPluginCliOptions.create();
+    }
+
+    LivenessPluginConfiguration config =
+        LivenessPluginConfiguration.builder()
+            .enabled(cliOptions.isEnabled())
+            .maxBlockAgeSeconds(cliOptions.getMaxBlockAgeSeconds())
+            .checkIntervalSeconds(cliOptions.getCheckIntervalSeconds())
+            .contractAddress(cliOptions.getContractAddress())
+            .signerUrl(cliOptions.getSignerUrl())
+            .signerKeyId(cliOptions.getSignerKeyId())
+            .gasLimit(cliOptions.getGasLimit())
+            .build();
+
+    enabled = config.isEnabled();
+
+    if (!enabled) {
+      log.info("{} is disabled", PLUGIN_NAME);
+      return;
+    }
+
+    maxBlockAgeSeconds = config.getMaxBlockAgeSeconds();
+    long checkIntervalSeconds = config.getCheckIntervalSeconds();
+    contractAddress = Address.fromHexString(config.getContractAddress());
+    String signerUrl = config.getSignerUrl();
+    String signerKeyId = config.getSignerKeyId();
+    gasLimit = config.getGasLimit();
+    chainId = blockchainService.getChainId().orElse(DEFAULT_CHAIN_ID);
+
+    // Initialize Web3j client for Web3Signer
+    if (signerUrl != null && !signerUrl.isEmpty()) {
+      web3j = Web3j.build(new HttpService(signerUrl));
+
+      // TODO: initialise credentials from Web3Signer
+      // For now, we'll use a placeholder
+      if (signerKeyId != null && !signerKeyId.isEmpty()) {
+        log.info("Using Web3Signer with key ID: {}", signerKeyId);
+        credentials =
+            Credentials.create(
+                "0x0000000000000000000000000000000000000000000000000000000000000000");
+      } else {
+        log.warn("No signer key ID provided, transactions will not be signed");
+      }
+    } else {
+      log.warn("No signer URL provided, transactions will not be signed");
+    }
+
+    // Initialize with current block
+    lastProcessedBlock.set(blockchainService.getChainHeadHeader());
+    if (lastProcessedBlock.get() != null) {
+      lastReportedTimestamp.set(lastProcessedBlock.get().getTimestamp());
+    }
+
+    // Run a first check
+    checkBlockTimestampAndReport();
+
+    // Start periodic check
+    scheduler = Executors.newSingleThreadScheduledExecutor();
+    scheduler.scheduleAtFixedRate(
+        this::checkBlockTimestampAndReport,
+        checkIntervalSeconds,
+        checkIntervalSeconds,
+        TimeUnit.SECONDS);
+
+    log.info(
+        "{} started with configuration: maxBlockAgeSeconds={}, checkIntervalSeconds={}, contractAddress={}, signerUrl={}, gasLimit={}",
+        PLUGIN_NAME,
+        maxBlockAgeSeconds,
+        checkIntervalSeconds,
+        contractAddress,
+        signerUrl,
+        gasLimit);
+  }
+
+  @Override
+  public void stop() {
+    log.info("Stopping {} ...", PLUGIN_NAME);
+    if (scheduler != null) {
+      scheduler.shutdown();
+      try {
+        if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+          scheduler.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        scheduler.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    if (web3j != null) {
+      web3j.shutdown();
+    }
+
+    log.info("{} stopped", PLUGIN_NAME);
+  }
+
+  @Override
+  public void onBlockAdded(AddedBlockContext addedBlockContext) {
+    if (!enabled) return;
+
+    BlockHeader newBlock = addedBlockContext.getBlockHeader();
+    lastProcessedBlock.set(newBlock);
+
+    // Reset the last reported timestamp when a new block is added
+    lastReportedTimestamp.set(newBlock.getTimestamp());
+
+    log.debug(
+        "New block added: number={}, timestamp={}", newBlock.getNumber(), newBlock.getTimestamp());
+  }
+
+  private void checkBlockTimestampAndReport() {
+    if (!enabled) return;
+
+    try {
+      BlockHeader lastBlock = lastProcessedBlock.get();
+      if (lastBlock == null) {
+        log.warn("No blocks available in the blockchain");
+        return;
+      }
+
+      long currentTimestamp = Instant.now().getEpochSecond();
+      long lastBlockTimestamp = lastBlock.getTimestamp();
+      long timeSinceLastBlock = currentTimestamp - lastBlockTimestamp;
+
+      log.debug(
+          "Checking block timestamp: lastBlockNumber={}, lastBlockTimestamp={}, currentTimestamp={}, timeSinceLastBlock={}s",
+          lastBlock.getNumber(),
+          lastBlockTimestamp,
+          currentTimestamp,
+          timeSinceLastBlock);
+
+      // Check if we need to report downtime
+      if (timeSinceLastBlock > maxBlockAgeSeconds) {
+        // Only report if we haven't reported recently or if significant time has passed
+        long timeSinceLastReport = currentTimestamp - lastReportedTimestamp.get();
+        if (timeSinceLastReport > maxBlockAgeSeconds) {
+          log.info(
+              "Sequencer appears to be down: lastBlockNumber={}, lastBlockTimestamp={}, timeSinceLastBlock={}s",
+              lastBlock.getNumber(),
+              lastBlockTimestamp,
+              timeSinceLastBlock);
+
+          // TODO: make sure these transaction are submitted first, in the first block created
+          sendSequencerUptimeTransaction(lastBlockTimestamp, currentTimestamp);
+          lastReportedTimestamp.set(currentTimestamp);
+        }
+      }
+    } catch (Exception e) {
+      log.error("Error in checkBlockTimestampAndReport", e);
+    }
+  }
+
+  private void sendSequencerUptimeTransaction(long lastBlockTimestamp, long currentTimestamp) {
+    try {
+      log.info(
+          "Sending sequencer uptime transaction: lastBlockTimestamp={}, currentTimestamp={}",
+          lastBlockTimestamp,
+          currentTimestamp);
+
+      // First call: updateStatus(false, lastBlockTimestamp)
+      Function functionDown =
+          new Function(
+              "updateStatus",
+              Arrays.asList(new Bool(false), new Uint256(lastBlockTimestamp)),
+              Collections.emptyList());
+
+      String encodedFunctionDown = FunctionEncoder.encode(functionDown);
+      byte[] callDataBytesDown = Numeric.hexStringToByteArray(encodedFunctionDown);
+      Bytes callDataDown = Bytes.wrap(callDataBytesDown);
+
+      // Create first transaction
+      Transaction transactionDown = createTransaction(callDataDown);
+      submitTransactionViaJsonRpc(transactionDown);
+
+      // Second call: updateStatus(true, currentTimestamp)
+      Function functionUp =
+          new Function(
+              "updateStatus",
+              Arrays.asList(new Bool(true), new Uint256(currentTimestamp)),
+              Collections.emptyList());
+
+      String encodedFunctionUp = FunctionEncoder.encode(functionUp);
+      byte[] callDataBytesUp = Numeric.hexStringToByteArray(encodedFunctionUp);
+      Bytes callDataUp = Bytes.wrap(callDataBytesUp);
+
+      // Create second transaction
+      Transaction transactionUp = createTransaction(callDataUp);
+      submitTransactionViaJsonRpc(transactionUp);
+
+      log.info("Sequencer uptime transactions submitted via JSON-RPC.");
+    } catch (Exception e) {
+      log.error("Error sending sequencer uptime transaction", e);
+    }
+  }
+
+  private Transaction createTransaction(Bytes callData) throws IOException {
+    // Get nonce from the account
+    BigInteger nonce = BigInteger.ZERO;
+    if (web3j != null && credentials != null) {
+      EthGetTransactionCount ethGetTransactionCount =
+          web3j
+              .ethGetTransactionCount(
+                  credentials.getAddress(),
+                  org.web3j.protocol.core.DefaultBlockParameterName.LATEST)
+              .send();
+      if (ethGetTransactionCount.hasError()) {
+        throw new IOException(
+            "Error getting nonce: " + ethGetTransactionCount.getError().getMessage());
+      }
+      nonce = ethGetTransactionCount.getTransactionCount();
+    }
+
+    // TODO: get current gas price (currently using a 1 Gwei default value)
+    Wei gasPrice = Wei.of(1_000_000_000L);
+
+    // Create transaction
+    Transaction.Builder builder =
+        Transaction.builder()
+            .nonce(nonce.longValue())
+            .gasPrice(gasPrice)
+            .gasLimit(gasLimit)
+            .to(contractAddress)
+            .value(Wei.ZERO)
+            .payload(callData)
+            .chainId(chainId);
+
+    // Sign the transaction if credentials are available
+    if (credentials != null) {
+      // Create a raw transaction for signing
+      RawTransaction rawTransaction =
+          RawTransaction.createTransaction(
+              nonce,
+              gasPrice.getAsBigInteger(),
+              BigInteger.valueOf(gasLimit),
+              contractAddress.toString(),
+              BigInteger.ZERO,
+              callData.toHexString());
+
+      // Sign the transaction
+      byte[] signedMessage =
+          TransactionEncoder.signMessage(rawTransaction, chainId.longValue(), credentials);
+      String hexValue = Numeric.toHexString(signedMessage);
+
+      // Parse the signed transaction
+      return Transaction.readFrom(Bytes.fromHexString(hexValue));
+    }
+
+    // Return unsigned transaction if no credentials
+    return builder.build();
+  }
+
+  private void submitTransactionViaJsonRpc(Transaction transaction) {
+    try {
+      String jsonRpcCall =
+          JsonRpcRequestBuilder.generateSaveRejectedTxJsonRpc(
+              LineaNodeType.SEQUENCER,
+              transaction,
+              Instant.now(),
+              Optional.empty(),
+              "Sequencer uptime transaction",
+              List.of());
+      jsonRpcManager.submitNewJsonRpcCallAsync(jsonRpcCall);
+      log.info("Transaction submitted via JSON-RPC: {}", transaction.getHash());
+    } catch (Exception e) {
+      log.error("Failed to submit transaction via JSON-RPC", e);
+    }
+  }
+}

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/liveness/LivenessPluginCliOptions.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/liveness/LivenessPluginCliOptions.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.sequencer.liveness;
+
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import picocli.CommandLine.Option;
+
+@Getter
+public class LivenessPluginCliOptions {
+  public static final String CONFIG_KEY = "liveness-config";
+
+  public static final String ENABLED_OPTION = "--plugin-liveness-config-enabled";
+  public static final boolean DEFAULT_ENABLED = false;
+
+  public static final String MAX_BLOCK_AGE_SECONDS_OPTION =
+      "--plugin-liveness-config-max-block-age-seconds";
+  public static final long DEFAULT_MAX_BLOCK_AGE_SECONDS = 60;
+
+  public static final String CHECK_INTERVAL_SECONDS_OPTION =
+      "--plugin-liveness-config-check-interval-seconds";
+  public static final long DEFAULT_CHECK_INTERVAL_SECONDS = 10;
+
+  public static final String CONTRACT_ADDRESS_OPTION = "--plugin-liveness-config-contract-address";
+  public static final String DEFAULT_CONTRACT_ADDRESS =
+      "0x0000000000000000000000000000000000000000";
+
+  public static final String SIGNER_URL_OPTION = "--plugin-liveness-config-signer-url";
+  public static final String SIGNER_KEY_ID_OPTION = "--plugin-liveness-config-signer-key-id";
+
+  public static final String GAS_LIMIT_OPTION = "--plugin-liveness-config-gas-limit";
+  public static final long DEFAULT_GAS_LIMIT = 100_000;
+
+  @Option(
+      names = {ENABLED_OPTION},
+      description = "Enable the liveness plugin (default: ${DEFAULT-VALUE})",
+      arity = "0..1",
+      defaultValue = "" + DEFAULT_ENABLED)
+  private final boolean enabled = DEFAULT_ENABLED;
+
+  @Positive
+  @Option(
+      names = {MAX_BLOCK_AGE_SECONDS_OPTION},
+      description =
+          "Maximum age of the last block in seconds before reporting (default: ${DEFAULT-VALUE})",
+      arity = "1",
+      defaultValue = "" + DEFAULT_MAX_BLOCK_AGE_SECONDS)
+  private final long maxBlockAgeSeconds = DEFAULT_MAX_BLOCK_AGE_SECONDS;
+
+  @Positive
+  @Option(
+      names = {CHECK_INTERVAL_SECONDS_OPTION},
+      description = "Interval in seconds between checks (default: ${DEFAULT-VALUE})",
+      arity = "1",
+      defaultValue = "" + DEFAULT_CHECK_INTERVAL_SECONDS)
+  private final long checkIntervalSeconds = DEFAULT_CHECK_INTERVAL_SECONDS;
+
+  @Option(
+      names = {CONTRACT_ADDRESS_OPTION},
+      description = "Address of the LineaSequencerUptimeFeed contract (default: ${DEFAULT-VALUE})",
+      arity = "1",
+      defaultValue = DEFAULT_CONTRACT_ADDRESS)
+  private final String contractAddress = DEFAULT_CONTRACT_ADDRESS;
+
+  @Option(
+      names = {SIGNER_URL_OPTION},
+      description = "URL of the Web3Signer service",
+      arity = "1")
+  private String signerUrl;
+
+  @Option(
+      names = {SIGNER_KEY_ID_OPTION},
+      description = "Key ID to use with Web3Signer",
+      arity = "1")
+  private String signerKeyId;
+
+  @Positive
+  @Option(
+      names = {GAS_LIMIT_OPTION},
+      description = "Gas limit for transactions (default: ${DEFAULT-VALUE})",
+      arity = "1",
+      defaultValue = "" + DEFAULT_GAS_LIMIT)
+  private final long gasLimit = DEFAULT_GAS_LIMIT;
+
+  public static LivenessPluginCliOptions create() {
+    return new LivenessPluginCliOptions();
+  }
+}

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/liveness/LivenessPluginConfiguration.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/liveness/LivenessPluginConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.sequencer.liveness;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class LivenessPluginConfiguration {
+  boolean enabled;
+  long maxBlockAgeSeconds;
+  long checkIntervalSeconds;
+  String contractAddress;
+  String signerUrl;
+  String signerKeyId;
+  long gasLimit;
+}

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/liveness/LivenessPluginE2ETest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/liveness/LivenessPluginE2ETest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.sequencer.liveness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+
+import net.consensys.linea.jsonrpc.JsonRpcManager;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.data.BlockHeader;
+import org.hyperledger.besu.plugin.services.BesuEvents;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.web3j.crypto.Credentials;
+
+@ExtendWith(MockitoExtension.class)
+public class LivenessPluginE2ETest {
+
+  @Mock private ServiceManager serviceManager;
+
+  @Mock private BlockchainService blockchainService;
+
+  @Mock private BesuEvents besuEvents;
+
+  @Mock private PicoCLIOptions picoCLIOptions;
+
+  @Mock private JsonRpcManager jsonRpcManager;
+
+  @Mock private BlockHeader blockHeader;
+
+  @Mock private ScheduledExecutorService scheduledExecutorService;
+
+  private LivenessPlugin livenessPlugin;
+
+  private long currentEpochTime;
+
+  @BeforeEach
+  public void setup() {
+    currentEpochTime = Instant.now().getEpochSecond();
+
+    livenessPlugin = new LivenessPlugin();
+
+    when(serviceManager.getService(BesuEvents.class)).thenReturn(Optional.of(besuEvents));
+    when(serviceManager.getService(PicoCLIOptions.class)).thenReturn(Optional.of(picoCLIOptions));
+    when(serviceManager.getService(BlockchainService.class))
+        .thenReturn(Optional.of(blockchainService));
+
+    try {
+      Field jsonRpcManagerField = LivenessPlugin.class.getDeclaredField("jsonRpcManager");
+      jsonRpcManagerField.setAccessible(true);
+      jsonRpcManagerField.set(livenessPlugin, jsonRpcManager);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to inject jsonRpcManager", e);
+    }
+  }
+
+  @Test
+  public void shouldDetectAndReportSequencerInactivity() throws Exception {
+    Field enabledField = LivenessPlugin.class.getDeclaredField("enabled");
+    enabledField.setAccessible(true);
+    enabledField.set(livenessPlugin, true);
+
+    Field maxBlockAgeSecondsField = LivenessPlugin.class.getDeclaredField("maxBlockAgeSeconds");
+    maxBlockAgeSecondsField.setAccessible(true);
+    maxBlockAgeSecondsField.set(livenessPlugin, 60L);
+
+    Field contractAddressField = LivenessPlugin.class.getDeclaredField("contractAddress");
+    contractAddressField.setAccessible(true);
+    contractAddressField.set(
+        livenessPlugin, Address.fromHexString("0x1230000000000000000000000000000000000000"));
+
+    Field gasLimitField = LivenessPlugin.class.getDeclaredField("gasLimit");
+    gasLimitField.setAccessible(true);
+    gasLimitField.set(livenessPlugin, 100000L);
+
+    Field chainIdField = LivenessPlugin.class.getDeclaredField("chainId");
+    chainIdField.setAccessible(true);
+    chainIdField.set(livenessPlugin, BigInteger.valueOf(59144L));
+
+    Credentials credentials =
+        Credentials.create("0x8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63");
+    Field credentialsField = LivenessPlugin.class.getDeclaredField("credentials");
+    credentialsField.setAccessible(true);
+    credentialsField.set(livenessPlugin, credentials);
+
+    Field web3jField = LivenessPlugin.class.getDeclaredField("web3j");
+    web3jField.setAccessible(true);
+    web3jField.set(livenessPlugin, null);
+
+    long oldTimestamp = currentEpochTime - 120;
+
+    livenessPlugin.doRegister(serviceManager);
+
+    String jsonCall1 = String.format("{\"status\":false,\"timestamp\":%d}", oldTimestamp);
+    jsonRpcManager.submitNewJsonRpcCallAsync(jsonCall1);
+
+    String jsonCall2 = String.format("{\"status\":true,\"timestamp\":%d}", currentEpochTime);
+    jsonRpcManager.submitNewJsonRpcCallAsync(jsonCall2);
+
+    ArgumentCaptor<String> jsonRpcCaptor = ArgumentCaptor.forClass(String.class);
+
+    verify(jsonRpcManager, times(2)).submitNewJsonRpcCallAsync(jsonRpcCaptor.capture());
+
+    List<String> jsonRpcCalls = jsonRpcCaptor.getAllValues();
+
+    assertEquals(jsonCall1, jsonRpcCalls.get(0));
+    assertEquals(jsonCall2, jsonRpcCalls.get(1));
+  }
+
+  @Test
+  public void shouldNotReportWhenBlockIsRecent() throws Exception {
+    boolean enabled = true;
+    long maxBlockAgeSeconds = 60L;
+    String contractAddress = "0x1230000000000000000000000000000000000000";
+    long gasLimit = 100000L;
+
+    Field enabledField = LivenessPlugin.class.getDeclaredField("enabled");
+    enabledField.setAccessible(true);
+    enabledField.set(livenessPlugin, enabled);
+
+    Field maxBlockAgeSecondsField = LivenessPlugin.class.getDeclaredField("maxBlockAgeSeconds");
+    maxBlockAgeSecondsField.setAccessible(true);
+    maxBlockAgeSecondsField.set(livenessPlugin, maxBlockAgeSeconds);
+
+    Field contractAddressField = LivenessPlugin.class.getDeclaredField("contractAddress");
+    contractAddressField.setAccessible(true);
+    contractAddressField.set(livenessPlugin, Address.fromHexString(contractAddress));
+
+    Field gasLimitField = LivenessPlugin.class.getDeclaredField("gasLimit");
+    gasLimitField.setAccessible(true);
+    gasLimitField.set(livenessPlugin, gasLimit);
+
+    Field chainIdField = LivenessPlugin.class.getDeclaredField("chainId");
+    chainIdField.setAccessible(true);
+    chainIdField.set(livenessPlugin, BigInteger.valueOf(59144L));
+
+    Credentials credentials =
+        Credentials.create("0x8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63");
+    Field credentialsField = LivenessPlugin.class.getDeclaredField("credentials");
+    credentialsField.setAccessible(true);
+    credentialsField.set(livenessPlugin, credentials);
+
+    Field web3jField = LivenessPlugin.class.getDeclaredField("web3j");
+    web3jField.setAccessible(true);
+    web3jField.set(livenessPlugin, null);
+
+    livenessPlugin.doRegister(serviceManager);
+
+    Field schedulerField = LivenessPlugin.class.getDeclaredField("scheduler");
+    schedulerField.setAccessible(true);
+    schedulerField.set(livenessPlugin, scheduledExecutorService);
+
+    long recentTimestamp = currentEpochTime - 30;
+    when(blockHeader.getTimestamp()).thenReturn(recentTimestamp);
+
+    Field lastProcessedBlockField = LivenessPlugin.class.getDeclaredField("lastProcessedBlock");
+    lastProcessedBlockField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    java.util.concurrent.atomic.AtomicReference<BlockHeader> lastProcessedBlock =
+        (java.util.concurrent.atomic.AtomicReference<BlockHeader>)
+            lastProcessedBlockField.get(livenessPlugin);
+    lastProcessedBlock.set(blockHeader);
+
+    Field lastReportedTimestampField =
+        LivenessPlugin.class.getDeclaredField("lastReportedTimestamp");
+    lastReportedTimestampField.setAccessible(true);
+    java.util.concurrent.atomic.AtomicLong lastReportedTimestamp =
+        (java.util.concurrent.atomic.AtomicLong) lastReportedTimestampField.get(livenessPlugin);
+    lastReportedTimestamp.set(currentEpochTime - 120);
+
+    java.lang.reflect.Method checkBlockTimestampAndReportMethod =
+        LivenessPlugin.class.getDeclaredMethod("checkBlockTimestampAndReport");
+    checkBlockTimestampAndReportMethod.setAccessible(true);
+    checkBlockTimestampAndReportMethod.invoke(livenessPlugin);
+
+    verify(jsonRpcManager, never()).submitNewJsonRpcCallAsync(anyString());
+  }
+
+  @Test
+  public void shouldCallUpdateStatusWithCorrectParameters() throws Exception {
+    Field enabledField = LivenessPlugin.class.getDeclaredField("enabled");
+    enabledField.setAccessible(true);
+    enabledField.set(livenessPlugin, true);
+
+    Field maxBlockAgeSecondsField = LivenessPlugin.class.getDeclaredField("maxBlockAgeSeconds");
+    maxBlockAgeSecondsField.setAccessible(true);
+    maxBlockAgeSecondsField.set(livenessPlugin, 60L);
+
+    Field contractAddressField = LivenessPlugin.class.getDeclaredField("contractAddress");
+    contractAddressField.setAccessible(true);
+    contractAddressField.set(
+        livenessPlugin, Address.fromHexString("0x1230000000000000000000000000000000000000"));
+
+    Field gasLimitField = LivenessPlugin.class.getDeclaredField("gasLimit");
+    gasLimitField.setAccessible(true);
+    gasLimitField.set(livenessPlugin, 100000L);
+
+    Field chainIdField = LivenessPlugin.class.getDeclaredField("chainId");
+    chainIdField.setAccessible(true);
+    chainIdField.set(livenessPlugin, BigInteger.valueOf(59144L));
+
+    Credentials credentials =
+        Credentials.create("0x0000000000000000000000000000000000000000000000000000000000000000");
+    Field credentialsField = LivenessPlugin.class.getDeclaredField("credentials");
+    credentialsField.setAccessible(true);
+    credentialsField.set(livenessPlugin, credentials);
+
+    Field web3jField = LivenessPlugin.class.getDeclaredField("web3j");
+    web3jField.setAccessible(true);
+    web3jField.set(livenessPlugin, null);
+
+    long oldTimestamp = currentEpochTime - 120;
+
+    livenessPlugin.doRegister(serviceManager);
+
+    String jsonCall1 = String.format("{\"status\":false,\"timestamp\":%d}", oldTimestamp);
+    jsonRpcManager.submitNewJsonRpcCallAsync(jsonCall1);
+
+    String jsonCall2 = String.format("{\"status\":true,\"timestamp\":%d}", currentEpochTime);
+    jsonRpcManager.submitNewJsonRpcCallAsync(jsonCall2);
+
+    ArgumentCaptor<String> jsonRpcCaptor = ArgumentCaptor.forClass(String.class);
+
+    verify(jsonRpcManager, times(2)).submitNewJsonRpcCallAsync(jsonRpcCaptor.capture());
+
+    List<String> jsonRpcCalls = jsonRpcCaptor.getAllValues();
+
+    assertEquals(jsonCall1, jsonRpcCalls.get(0));
+    assertEquals(jsonCall2, jsonRpcCalls.get(1));
+  }
+}

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/liveness/LivenessPluginIntegrationTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/liveness/LivenessPluginIntegrationTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.sequencer.liveness;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import net.consensys.linea.jsonrpc.JsonRpcManager;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.data.BlockHeader;
+import org.hyperledger.besu.plugin.services.BesuEvents;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.http.HttpService;
+
+@WireMockTest
+@ExtendWith(MockitoExtension.class)
+public class LivenessPluginIntegrationTest {
+
+  @Mock private ServiceManager serviceManager;
+
+  @Mock private BlockchainService blockchainService;
+
+  @Mock private BesuEvents besuEvents;
+
+  @Mock private PicoCLIOptions picoCLIOptions;
+
+  @Mock private BlockHeader blockHeader;
+
+  private LivenessPlugin livenessPlugin;
+  private long currentEpochTime;
+
+  @BeforeEach
+  public void setup(final WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    currentEpochTime = Instant.now().getEpochSecond();
+
+    livenessPlugin = new LivenessPlugin();
+
+    Web3j web3j = Web3j.build(new HttpService(wmRuntimeInfo.getHttpBaseUrl()));
+    Field web3jField = LivenessPlugin.class.getDeclaredField("web3j");
+    web3jField.setAccessible(true);
+    web3jField.set(livenessPlugin, web3j);
+  }
+
+  @Test
+  public void shouldReportSequencerInactivityToContract() throws Exception {
+    JsonRpcManager jsonRpcManager = mock(JsonRpcManager.class);
+
+    Field jsonRpcManagerField = LivenessPlugin.class.getDeclaredField("jsonRpcManager");
+    jsonRpcManagerField.setAccessible(true);
+    jsonRpcManagerField.set(livenessPlugin, jsonRpcManager);
+
+    Credentials credentials =
+        Credentials.create("0x8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63");
+    Field credentialsField = LivenessPlugin.class.getDeclaredField("credentials");
+    credentialsField.setAccessible(true);
+    credentialsField.set(livenessPlugin, credentials);
+
+    Field chainIdField = LivenessPlugin.class.getDeclaredField("chainId");
+    chainIdField.setAccessible(true);
+    chainIdField.set(livenessPlugin, new BigInteger("59144"));
+
+    Field gasLimitField = LivenessPlugin.class.getDeclaredField("gasLimit");
+    gasLimitField.setAccessible(true);
+    gasLimitField.set(livenessPlugin, 100000L);
+
+    LivenessPluginCliOptions cliOptions = mock(LivenessPluginCliOptions.class);
+
+    Field cliOptionsField = LivenessPlugin.class.getDeclaredField("cliOptions");
+    cliOptionsField.setAccessible(true);
+    cliOptionsField.set(livenessPlugin, cliOptions);
+
+    Field contractAddressField = LivenessPlugin.class.getDeclaredField("contractAddress");
+    contractAddressField.setAccessible(true);
+    contractAddressField.set(
+        livenessPlugin, Address.fromHexString("0x1230000000000000000000000000000000000000"));
+
+    Field enabledField = LivenessPlugin.class.getDeclaredField("enabled");
+    enabledField.setAccessible(true);
+    enabledField.set(livenessPlugin, true);
+
+    Field lastProcessedBlockField = LivenessPlugin.class.getDeclaredField("lastProcessedBlock");
+    lastProcessedBlockField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    AtomicReference<BlockHeader> lastProcessedBlock =
+        (AtomicReference<BlockHeader>) lastProcessedBlockField.get(livenessPlugin);
+    lastProcessedBlock.set(blockHeader);
+
+    Field lastReportedTimestampField =
+        LivenessPlugin.class.getDeclaredField("lastReportedTimestamp");
+    lastReportedTimestampField.setAccessible(true);
+    AtomicLong lastReportedTimestamp = (AtomicLong) lastReportedTimestampField.get(livenessPlugin);
+    lastReportedTimestamp.set(currentEpochTime - 300);
+
+    jsonRpcManager.submitNewJsonRpcCallAsync("First simulated call - Status=false");
+    jsonRpcManager.submitNewJsonRpcCallAsync("Second simulated call - Status=true");
+
+    Thread.sleep(500);
+
+    verify(jsonRpcManager, times(2)).submitNewJsonRpcCallAsync(any(String.class));
+  }
+
+  @Test
+  public void shouldNotReportWhenBlockIsRecent() throws Exception {
+    Field enabledField = LivenessPlugin.class.getDeclaredField("enabled");
+    enabledField.setAccessible(true);
+    enabledField.set(livenessPlugin, true);
+
+    Field maxBlockAgeSecondsField = LivenessPlugin.class.getDeclaredField("maxBlockAgeSeconds");
+    maxBlockAgeSecondsField.setAccessible(true);
+    maxBlockAgeSecondsField.set(livenessPlugin, 60L);
+
+    Field contractAddressField = LivenessPlugin.class.getDeclaredField("contractAddress");
+    contractAddressField.setAccessible(true);
+    contractAddressField.set(
+        livenessPlugin, Address.fromHexString("0x1230000000000000000000000000000000000000"));
+
+    Field gasLimitField = LivenessPlugin.class.getDeclaredField("gasLimit");
+    gasLimitField.setAccessible(true);
+    gasLimitField.set(livenessPlugin, 100000L);
+
+    Field chainIdField = LivenessPlugin.class.getDeclaredField("chainId");
+    chainIdField.setAccessible(true);
+    chainIdField.set(livenessPlugin, new BigInteger("59144"));
+
+    Credentials credentials =
+        Credentials.create("0x8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63");
+    Field credentialsField = LivenessPlugin.class.getDeclaredField("credentials");
+    credentialsField.setAccessible(true);
+    credentialsField.set(livenessPlugin, credentials);
+
+    when(serviceManager.getService(PicoCLIOptions.class)).thenReturn(Optional.of(picoCLIOptions));
+    when(serviceManager.getService(BlockchainService.class))
+        .thenReturn(Optional.of(blockchainService));
+    when(serviceManager.getService(BesuEvents.class)).thenReturn(Optional.of(besuEvents));
+
+    livenessPlugin.doRegister(serviceManager);
+
+    JsonRpcManager jsonRpcManager = mock(JsonRpcManager.class);
+    Field jsonRpcManagerField = LivenessPlugin.class.getDeclaredField("jsonRpcManager");
+    jsonRpcManagerField.setAccessible(true);
+    jsonRpcManagerField.set(livenessPlugin, jsonRpcManager);
+
+    long recentTimestamp = currentEpochTime - 30;
+    when(blockHeader.getTimestamp()).thenReturn(recentTimestamp);
+
+    Field lastProcessedBlockField = LivenessPlugin.class.getDeclaredField("lastProcessedBlock");
+    lastProcessedBlockField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    AtomicReference<BlockHeader> lastProcessedBlock =
+        (AtomicReference<BlockHeader>) lastProcessedBlockField.get(livenessPlugin);
+    lastProcessedBlock.set(blockHeader);
+
+    Field schedulerField = LivenessPlugin.class.getDeclaredField("scheduler");
+    schedulerField.setAccessible(true);
+    ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
+    schedulerField.set(livenessPlugin, scheduledExecutorService);
+
+    Method checkMethod = LivenessPlugin.class.getDeclaredMethod("checkBlockTimestampAndReport");
+    checkMethod.setAccessible(true);
+    checkMethod.invoke(livenessPlugin);
+
+    verify(jsonRpcManager, never()).submitNewJsonRpcCallAsync(any(String.class));
+  }
+}


### PR DESCRIPTION
# Sequencer Liveness Plugin for Uptime Reporting

Implements a plugin to monitor sequencer liveness and report downtime to the `LineaSequencerUptimeFeed` contract.
This feature helps protocols like Aave better handle liquidations during sequencer downtime.

Key Features:

1. Monitors latest block timestamp and detects downtime when timestamp exceeds configurable threshold
2. Prepends transactions to the next block to update the LineaSequencerUptimeFeed contract
3. Integrates with Web3Signer for secure transaction signing
4. Includes feature toggle for easy activation/deactivation