### PR TITLE
Extend parameters validation of bundles and reprocessing the same request

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSendBundle.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSendBundle.java
@@ -14,6 +14,7 @@
  */
 package net.consensys.linea.rpc.methods;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +23,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.rpc.services.BundlePoolService;
 import net.consensys.linea.rpc.services.BundlePoolService.TransactionBundle;
@@ -32,14 +36,23 @@ import org.hyperledger.besu.datatypes.parameters.UnsignedLongParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.util.DomainObjectDecodeUtils;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.exception.PluginRpcEndpointException;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 import org.hyperledger.besu.plugin.services.rpc.RpcMethodError;
 
 @Slf4j
+@RequiredArgsConstructor
 public class LineaSendBundle {
   private static final AtomicInteger LOG_SEQUENCE = new AtomicInteger();
+  private static final int MAX_TRACKED_SEEN_REQUESTS = 1_000;
   private final JsonRpcParameter parameterParser = new JsonRpcParameter();
+  private final Cache<BundleParameter, Instant> recentlySeenRequestsCache =
+      Caffeine.newBuilder()
+          .maximumSize(MAX_TRACKED_SEEN_REQUESTS)
+          .expireAfterAccess(Duration.ofMinutes(1))
+          .build();
+  private final BlockchainService blockchainService;
   private BundlePoolService bundlePool;
 
   public LineaSendBundle init(BundlePoolService bundlePoolService) {
@@ -62,15 +75,12 @@ public class LineaSendBundle {
     try {
       final BundleParameter bundleParams = parseRequest(logId, request.getParams());
 
-      if (bundleParams.maxTimestamp.isPresent()
-          && bundleParams.maxTimestamp.get() < Instant.now().getEpochSecond()) {
-        throw new Exception("bundle max timestamp is in the past");
-      }
+      validateParameters(bundleParams);
 
-      var optBundleUUID = bundleParams.replacementUUID.map(UUID::fromString);
+      final var optBundleUUID = bundleParams.replacementUUID.map(UUID::fromString);
 
       // use replacement UUID hashed if present, otherwise the hash of the transactions themselves
-      var optBundleHash =
+      final var optBundleHash =
           optBundleUUID
               .map(LineaLimitedBundlePool::UUIDToHash)
               .or(
@@ -80,30 +90,67 @@ public class LineaSendBundle {
                           .reduce(Bytes::concatenate)
                           .map(Hash::hash));
 
-      if (optBundleHash.isPresent()) {
-        Hash bundleHash = optBundleHash.get();
-        final List<Transaction> txs =
-            bundleParams.txs.stream().map(DomainObjectDecodeUtils::decodeRawTransaction).toList();
+      return optBundleHash
+          .map(
+              bundleHash -> {
+                final List<Transaction> txs =
+                    bundleParams.txs.stream()
+                        .map(DomainObjectDecodeUtils::decodeRawTransaction)
+                        .toList();
 
-        if (!txs.isEmpty()) {
-          bundlePool.putOrReplace(
-              bundleHash,
-              new TransactionBundle(
-                  bundleHash,
-                  txs,
-                  bundleParams.blockNumber,
-                  bundleParams.minTimestamp,
-                  bundleParams.maxTimestamp,
-                  bundleParams.revertingTxHashes()));
-          return new BundleResponse(bundleHash.toHexString());
-        }
-      }
-      // otherwise boom.
-      throw new RuntimeException("Malformed bundle, no bundle transactions present");
+                bundlePool.putOrReplace(
+                    bundleHash,
+                    new TransactionBundle(
+                        bundleHash,
+                        txs,
+                        bundleParams.blockNumber,
+                        bundleParams.minTimestamp,
+                        bundleParams.maxTimestamp,
+                        bundleParams.revertingTxHashes()));
+                return new BundleResponse(bundleHash.toHexString());
+              })
+          .orElseThrow(
+              () ->
+                  // otherwise boom.
+                  new RuntimeException("Malformed bundle, no bundle transactions present"));
 
     } catch (final Exception e) {
       throw new PluginRpcEndpointException(new LineaSendBundleError(e.getMessage()));
     }
+  }
+
+  private void validateParameters(final BundleParameter bundleParams) {
+    // synchronized to avoid that 2 parallel requests with the same parameters
+    // will be both processed
+    synchronized (recentlySeenRequestsCache) {
+      final var alreadySeenAt = recentlySeenRequestsCache.getIfPresent(bundleParams);
+      if (alreadySeenAt != null) {
+        throw new IllegalArgumentException(
+            "request already seen " + Duration.between(alreadySeenAt, Instant.now()) + " ago");
+      }
+      recentlySeenRequestsCache.put(bundleParams, Instant.now());
+    }
+
+    final var chainHeadBlockNumber = blockchainService.getChainHeadHeader().getNumber();
+    if (bundleParams.blockNumber <= chainHeadBlockNumber) {
+      throw new IllegalArgumentException(
+          "bundle block number "
+              + bundleParams.blockNumber
+              + " is not greater than current chain head block number "
+              + chainHeadBlockNumber);
+    }
+
+    bundleParams.maxTimestamp.ifPresent(
+        maxTimestamp -> {
+          final var now = Instant.now().getEpochSecond();
+          if (maxTimestamp < now) {
+            throw new IllegalArgumentException(
+                "bundle max timestamp "
+                    + maxTimestamp
+                    + " is in the past, current timestamp is "
+                    + now);
+          }
+        });
   }
 
   private BundleParameter parseRequest(final int logId, final Object[] params) {

--- a/sequencer/src/main/java/net/consensys/linea/rpc/services/BundlePoolService.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/services/BundlePoolService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import org.apache.tuweni.bytes.Bytes;
@@ -35,6 +36,7 @@ public interface BundlePoolService extends BesuService {
   /** TransactionBundle record representing a collection of pending transactions with metadata. */
   @Accessors(fluent = true)
   @Getter
+  @EqualsAndHashCode
   class TransactionBundle {
     private static final String FIELD_SEPARATOR = "|";
     private static final String ITEM_SEPARATOR = ",";

--- a/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaSendBundleEndpointPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/services/LineaSendBundleEndpointPlugin.java
@@ -34,7 +34,7 @@ public class LineaSendBundleEndpointPlugin extends AbstractLineaRequiredPlugin {
    */
   @Override
   public void doRegister(final ServiceManager serviceManager) {
-    lineaSendBundleMethod = new LineaSendBundle();
+    lineaSendBundleMethod = new LineaSendBundle(blockchainService);
 
     rpcEndpointService.registerRPCEndpoint(
         lineaSendBundleMethod.getNamespace(),


### PR DESCRIPTION
New bundle request parameters validations:
- check if the inclusion block number is not already present on chain
- avoid reprocessing the same request, useful for when multiple RPC nodes will forward the same request to the same sequencer.