### PR TITLE
Use JSON to save and restore bundles

### DIFF
--- a/sequencer/build.gradle
+++ b/sequencer/build.gradle
@@ -45,6 +45,8 @@ dependencies {
   implementation "${besuArtifactGroup}.internal:eth"
   implementation "${besuArtifactGroup}.internal:rlp"
 
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
+
   implementation 'com.github.ben-manes.caffeine:caffeine'
 
   implementation 'com.google.code.gson:gson'

--- a/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSendBundle.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSendBundle.java
@@ -14,6 +14,8 @@
  */
 package net.consensys.linea.rpc.methods;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_ABSENT;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -22,7 +24,9 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.RequiredArgsConstructor;
@@ -106,7 +110,8 @@ public class LineaSendBundle {
                         bundleParams.blockNumber,
                         bundleParams.minTimestamp,
                         bundleParams.maxTimestamp,
-                        bundleParams.revertingTxHashes()));
+                        bundleParams.revertingTxHashes(),
+                        optBundleUUID));
                 return new BundleResponse(bundleHash.toHexString());
               })
           .orElseThrow(
@@ -188,6 +193,8 @@ public class LineaSendBundle {
     }
   }
 
+  @JsonInclude(NON_ABSENT)
+  @JsonPropertyOrder({"blockNumber", "minTimestamp", "maxTimestamp"})
   public record BundleParameter(
       /*  array of signed transactions to execute in a bundle */
       List<String> txs,

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
@@ -184,6 +184,7 @@ class LineaTransactionSelectorFactoryTest {
         blockNumber,
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
   }
 

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/BundleConstraintTransactionSelectorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/BundleConstraintTransactionSelectorTest.java
@@ -107,6 +107,7 @@ class BundleConstraintTransactionSelectorTest {
         blockNumber,
         Optional.ofNullable(minTimestamp),
         Optional.ofNullable(maxTimestamp),
+        Optional.empty(),
         Optional.empty());
   }
 

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/MaxBundleBlockGasTransactionSelectorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/MaxBundleBlockGasTransactionSelectorTest.java
@@ -97,6 +97,7 @@ public class MaxBundleBlockGasTransactionSelectorTest {
             1L,
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     final var evaluationContexts =
         bundle.pendingTransactions().stream()


### PR DESCRIPTION
Replace custom serialization with standard JSON, so we can use standard parser and it will be also useful for future features.
Since the previous version of the serialization was not yet used anywhere, there is no need to keep supporting it.