### PR TITLE
Move reusable bundle related classes in a dedicated package

### DIFF
--- a/sequencer/src/main/java/net/consensys/linea/AbstractLineaSharedPrivateOptionsPlugin.java
+++ b/sequencer/src/main/java/net/consensys/linea/AbstractLineaSharedPrivateOptionsPlugin.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.bundles.BundlePoolService;
+import net.consensys.linea.bundles.LineaLimitedBundlePool;
 import net.consensys.linea.compress.LibCompress;
 import net.consensys.linea.config.LineaProfitabilityCliOptions;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
@@ -35,8 +37,6 @@ import net.consensys.linea.config.LineaTransactionSelectorCliOptions;
 import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import net.consensys.linea.plugins.AbstractLineaSharedOptionsPlugin;
 import net.consensys.linea.plugins.LineaOptionsPluginConfiguration;
-import net.consensys.linea.rpc.services.BundlePoolService;
-import net.consensys.linea.rpc.services.LineaLimitedBundlePool;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BesuEvents;

--- a/sequencer/src/main/java/net/consensys/linea/bundles/BundleParameter.java
+++ b/sequencer/src/main/java/net/consensys/linea/bundles/BundleParameter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.bundles;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_ABSENT;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.parameters.UnsignedLongParameter;
+
+@JsonInclude(NON_ABSENT)
+@JsonPropertyOrder({"blockNumber", "minTimestamp", "maxTimestamp"})
+public record BundleParameter(
+    /*  array of signed transactions to execute in a bundle */
+    List<String> txs,
+    /* block number for which this bundle is valid */
+    Long blockNumber,
+    /* Optional minimum timestamp from which this bundle is valid */
+    Optional<Long> minTimestamp,
+    /* Optional max timestamp for which this bundle is valid */
+    Optional<Long> maxTimestamp,
+    /* Optional list of transaction hashes which are allowed to revert */
+    Optional<List<Hash>> revertingTxHashes,
+    /* Optional UUID which can be used to replace or cancel this bundle */
+    Optional<String> replacementUUID,
+    /* Optional list of builders to share this bundle with */
+    Optional<List<String>> builders) {
+  @JsonCreator
+  public BundleParameter(
+      @JsonProperty("txs") final List<String> txs,
+      @JsonProperty("blockNumber") final UnsignedLongParameter blockNumber,
+      @JsonProperty("minTimestamp") final Optional<Long> minTimestamp,
+      @JsonProperty("maxTimestamp") final Optional<Long> maxTimestamp,
+      @JsonProperty("revertingTxHashes") final Optional<List<Hash>> revertingTxHashes,
+      @JsonProperty("replacementUUID") final Optional<String> replacementUUID,
+      @JsonProperty("builders") final Optional<List<String>> builders) {
+    this(
+        txs,
+        blockNumber.getValue(),
+        minTimestamp,
+        maxTimestamp,
+        revertingTxHashes,
+        replacementUUID,
+        builders);
+  }
+}

--- a/sequencer/src/main/java/net/consensys/linea/bundles/BundlePoolService.java
+++ b/sequencer/src/main/java/net/consensys/linea/bundles/BundlePoolService.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package net.consensys.linea.rpc.services;
+package net.consensys.linea.bundles;
 
 import java.util.List;
 import java.util.UUID;

--- a/sequencer/src/main/java/net/consensys/linea/bundles/LineaLimitedBundlePool.java
+++ b/sequencer/src/main/java/net/consensys/linea/bundles/LineaLimitedBundlePool.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.rpc.services;
+package net.consensys.linea.bundles;
 
 import static java.util.Collections.emptyList;
 

--- a/sequencer/src/main/java/net/consensys/linea/bundles/TransactionBundle.java
+++ b/sequencer/src/main/java/net/consensys/linea/bundles/TransactionBundle.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.rpc.services;
+package net.consensys.linea.bundles;
 
 import java.util.List;
 import java.util.Map;
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
-import net.consensys.linea.rpc.methods.LineaSendBundle;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.parameters.UnsignedLongParameter;
@@ -64,8 +63,8 @@ public class TransactionBundle {
     this.replacementUUID = replacementUUID;
   }
 
-  public LineaSendBundle.BundleParameter toBundleParameter() {
-    return new LineaSendBundle.BundleParameter(
+  public BundleParameter toBundleParameter() {
+    return new BundleParameter(
         pendingTransactions.stream().map(PendingBundleTx::toBase64String).toList(),
         new UnsignedLongParameter(blockNumber),
         minTimestamp,
@@ -76,13 +75,13 @@ public class TransactionBundle {
   }
 
   @JsonValue
-  public Map<Hash, LineaSendBundle.BundleParameter> serialize() {
+  public Map<Hash, BundleParameter> serialize() {
     return Map.of(bundleIdentifier, toBundleParameter());
   }
 
   @JsonCreator
   public static TransactionBundle deserialize(
-      final SequencedMap<Hash, LineaSendBundle.BundleParameter> serialized) {
+      final SequencedMap<Hash, BundleParameter> serialized) {
     final var entry = serialized.firstEntry();
     final var hash = entry.getKey();
     final var parameters = entry.getValue();

--- a/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaCancelBundle.java
+++ b/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaCancelBundle.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.rpc.services.BundlePoolService;
+import net.consensys.linea.bundles.BundlePoolService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.plugin.services.exception.PluginRpcEndpointException;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactory.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactory.java
@@ -20,13 +20,13 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.bundles.BundlePoolService;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
 import net.consensys.linea.config.LineaTracerConfiguration;
 import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import net.consensys.linea.jsonrpc.JsonRpcManager;
 import net.consensys.linea.metrics.HistogramMetrics;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
-import net.consensys.linea.rpc.services.BundlePoolService;
 import net.consensys.linea.sequencer.txselection.selectors.LineaTransactionSelector;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.services.BlockchainService;

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/BundleConstraintTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/BundleConstraintTransactionSelector.java
@@ -18,7 +18,7 @@ import static java.lang.Boolean.TRUE;
 
 import java.time.Instant;
 
-import net.consensys.linea.rpc.services.TransactionBundle;
+import net.consensys.linea.bundles.TransactionBundle;
 import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.bundles.BundlePoolService;
+import net.consensys.linea.bundles.TransactionBundle;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
 import net.consensys.linea.config.LineaTracerConfiguration;
 import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
@@ -32,8 +34,6 @@ import net.consensys.linea.jsonrpc.JsonRpcManager;
 import net.consensys.linea.jsonrpc.JsonRpcRequestBuilder;
 import net.consensys.linea.metrics.HistogramMetrics;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
-import net.consensys.linea.rpc.services.BundlePoolService;
-import net.consensys.linea.rpc.services.TransactionBundle;
 import net.consensys.linea.zktracer.ZkTracer;
 import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;

--- a/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/MaxBundleGasPerBlockTransactionSelector.java
+++ b/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/MaxBundleGasPerBlockTransactionSelector.java
@@ -19,7 +19,7 @@ import static net.consensys.linea.sequencer.txselection.LineaTransactionSelectio
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTED;
 
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.rpc.services.TransactionBundle;
+import net.consensys.linea.bundles.TransactionBundle;
 import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.hyperledger.besu.plugin.services.txselection.AbstractStatefulPluginTransactionSelector;

--- a/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaCancelBundleTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaCancelBundleTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
-import net.consensys.linea.rpc.services.LineaLimitedBundlePool;
+import net.consensys.linea.bundles.LineaLimitedBundlePool;
 import org.hyperledger.besu.plugin.services.exception.PluginRpcEndpointException;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 import org.junit.jupiter.api.BeforeEach;

--- a/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendBundleTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendBundleTest.java
@@ -32,8 +32,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import net.consensys.linea.rpc.services.LineaLimitedBundlePool;
-import net.consensys.linea.rpc.services.TransactionBundle;
+import net.consensys.linea.bundles.BundleParameter;
+import net.consensys.linea.bundles.LineaLimitedBundlePool;
+import net.consensys.linea.bundles.TransactionBundle;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
@@ -81,8 +82,8 @@ class LineaSendBundleTest {
     Optional<Long> minTimestamp = Optional.of(1000L);
     Optional<Long> maxTimestamp = Optional.of(System.currentTimeMillis() + 5000L);
 
-    LineaSendBundle.BundleParameter bundleParams =
-        new LineaSendBundle.BundleParameter(
+    BundleParameter bundleParams =
+        new BundleParameter(
             transactions, 123L, minTimestamp, maxTimestamp, empty(), empty(), empty());
 
     PluginRpcRequest request = mock(PluginRpcRequest.class);
@@ -105,8 +106,8 @@ class LineaSendBundleTest {
     Optional<Long> minTimestamp = Optional.of(1000L);
     Optional<Long> maxTimestamp = Optional.of(System.currentTimeMillis() + 5000L);
 
-    LineaSendBundle.BundleParameter bundleParams =
-        new LineaSendBundle.BundleParameter(
+    BundleParameter bundleParams =
+        new BundleParameter(
             transactions,
             123L,
             minTimestamp,
@@ -128,7 +129,7 @@ class LineaSendBundleTest {
     // Replace bundle:
     transactions = List.of(mockTX2.encoded().toHexString(), mockTX1.encoded().toHexString());
     bundleParams =
-        new LineaSendBundle.BundleParameter(
+        new BundleParameter(
             transactions,
             12345L,
             minTimestamp,
@@ -157,9 +158,8 @@ class LineaSendBundleTest {
   void testExecute_ExpiredBundle() {
     List<String> transactions = List.of(mockTX1.encoded().toHexString());
     Optional<Long> maxTimestamp = Optional.of(5000L);
-    LineaSendBundle.BundleParameter bundleParams =
-        new LineaSendBundle.BundleParameter(
-            transactions, 123L, empty(), maxTimestamp, empty(), empty(), empty());
+    BundleParameter bundleParams =
+        new BundleParameter(transactions, 123L, empty(), maxTimestamp, empty(), empty(), empty());
 
     PluginRpcRequest request = mock(PluginRpcRequest.class);
     when(request.getParams()).thenReturn(new Object[] {bundleParams});
@@ -173,8 +173,8 @@ class LineaSendBundleTest {
   @Test
   void testExecute_BundleForBlockAlreadyInChain_ThrowsException() {
     List<String> transactions = List.of(mockTX1.encoded().toHexString());
-    LineaSendBundle.BundleParameter bundleParams =
-        new LineaSendBundle.BundleParameter(
+    BundleParameter bundleParams =
+        new BundleParameter(
             transactions, CHAIN_HEAD_BLOCK_NUMBER, empty(), empty(), empty(), empty(), empty());
 
     PluginRpcRequest request = mock(PluginRpcRequest.class);
@@ -204,8 +204,8 @@ class LineaSendBundleTest {
   @Test
   void testExecute_DuplicateRequest_ThrowsException() {
     List<String> transactions = List.of(mockTX1.encoded().toHexString());
-    LineaSendBundle.BundleParameter bundleParams1 =
-        new LineaSendBundle.BundleParameter(
+    BundleParameter bundleParams1 =
+        new BundleParameter(
             transactions, CHAIN_HEAD_BLOCK_NUMBER + 1, empty(), empty(), empty(), empty(), empty());
 
     PluginRpcRequest request1 = mock(PluginRpcRequest.class);
@@ -216,8 +216,8 @@ class LineaSendBundleTest {
     // first time we send the request it works
     assertThat(response1.bundleHash()).isEqualTo(Hash.hash(mockTX1.encoded()).toHexString());
 
-    LineaSendBundle.BundleParameter bundleParams2 =
-        new LineaSendBundle.BundleParameter(
+    BundleParameter bundleParams2 =
+        new BundleParameter(
             transactions, CHAIN_HEAD_BLOCK_NUMBER + 1, empty(), empty(), empty(), empty(), empty());
 
     PluginRpcRequest request2 = mock(PluginRpcRequest.class);
@@ -231,9 +231,8 @@ class LineaSendBundleTest {
 
   @Test
   void testExecute_EmptyTransactions_ThrowsException() {
-    LineaSendBundle.BundleParameter bundleParams =
-        new LineaSendBundle.BundleParameter(
-            List.of(), 123L, empty(), empty(), empty(), empty(), empty());
+    BundleParameter bundleParams =
+        new BundleParameter(List.of(), 123L, empty(), empty(), empty(), empty(), empty());
 
     PluginRpcRequest request = mock(PluginRpcRequest.class);
     when(request.getParams()).thenReturn(new Object[] {bundleParams});
@@ -251,9 +250,8 @@ class LineaSendBundleTest {
   @Test
   void testExecute_FrozenPool_ThrowsException() {
     List<String> transactions = List.of(mockTX1.encoded().toHexString());
-    LineaSendBundle.BundleParameter bundleParams =
-        new LineaSendBundle.BundleParameter(
-            transactions, 123L, empty(), empty(), empty(), empty(), empty());
+    BundleParameter bundleParams =
+        new BundleParameter(transactions, 123L, empty(), empty(), empty(), empty(), empty());
 
     PluginRpcRequest request = mock(PluginRpcRequest.class);
     when(request.getParams()).thenReturn(new Object[] {bundleParams});

--- a/sequencer/src/test/java/net/consensys/linea/rpc/services/LineaLimitedBundlePoolTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/rpc/services/LineaLimitedBundlePoolTest.java
@@ -16,7 +16,7 @@
 package net.consensys.linea.rpc.services;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static net.consensys.linea.rpc.services.LineaLimitedBundlePool.BUNDLE_SAVE_FILENAME;
+import static net.consensys.linea.bundles.LineaLimitedBundlePool.BUNDLE_SAVE_FILENAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import net.consensys.linea.bundles.LineaLimitedBundlePool;
+import net.consensys.linea.bundles.TransactionBundle;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SECPPrivateKey;

--- a/sequencer/src/test/java/net/consensys/linea/rpc/services/TransactionBundleTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/rpc/services/TransactionBundleTest.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import net.consensys.linea.bundles.TransactionBundle;
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SECPPrivateKey;
 import org.hyperledger.besu.crypto.SECPPublicKey;

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
@@ -32,13 +32,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import net.consensys.linea.bundles.BundlePoolService;
+import net.consensys.linea.bundles.LineaLimitedBundlePool;
+import net.consensys.linea.bundles.TransactionBundle;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
 import net.consensys.linea.config.LineaTracerConfiguration;
 import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
-import net.consensys.linea.rpc.services.BundlePoolService;
-import net.consensys.linea.rpc.services.LineaLimitedBundlePool;
-import net.consensys.linea.rpc.services.TransactionBundle;
 import net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator;
 import net.consensys.linea.sequencer.txselection.selectors.TraceLineLimitTransactionSelectorTest;
 import org.apache.tuweni.bytes.Bytes;

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/BundleConstraintTransactionSelectorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/BundleConstraintTransactionSelectorTest.java
@@ -23,7 +23,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
-import net.consensys.linea.rpc.services.TransactionBundle;
+import net.consensys.linea.bundles.TransactionBundle;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;

--- a/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/MaxBundleBlockGasTransactionSelectorTest.java
+++ b/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/MaxBundleBlockGasTransactionSelectorTest.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import net.consensys.linea.rpc.services.TransactionBundle;
+import net.consensys.linea.bundles.TransactionBundle;
 import net.consensys.linea.sequencer.txselection.selectors.MaxBundleGasPerBlockTransactionSelector.BundleGasTracker;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Hash;


### PR DESCRIPTION
No functional changes, just moving class around to make it easier to reuse some of them for the bundle store and forward feature